### PR TITLE
[#55] Update to mxnet v0.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.sln.docstates
 *.so
 *.o
+*.swp
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/example/Makefile
+++ b/example/Makefile
@@ -3,8 +3,16 @@ CUDA=-DMSHADOW_USE_CUDA=1
 
 #COMMFLAGS=-static -static-libgcc -static-libstdc++
 
-CFLAGS=$(COMMFLAGS) -I ../include -Wall -O3 -msse3 -funroll-loops -Wno-unused-parameter -Wno-unknown-pragmas -fopenmp 
-LDFLAGS=$(COMMFLAGS) -L ../lib/linux -lmxnet $(BLAS) $(CUDA) -lgomp -pthread
+CFLAGS=$(COMMFLAGS) -I ../include -Wall -O3 -msse3 -funroll-loops -Wno-unused-parameter -Wno-unknown-pragmas
+LDFLAGS=$(COMMFLAGS) -L ../lib/linux -lmxnet $(BLAS) $(CUDA) -pthread
+
+ifneq ($(OS), Windows_NT)
+	OS := $(shell uname)
+endif
+ifneq ($(OS), Darwin)
+	CFLAGS += -fopenmp
+	LDFLAGS += -lgomp
+endif
 
 all: mlp lenet lenet_with_mxdataiter alexnet googlenet inception_bn resnet
 

--- a/example/alexnet.cpp
+++ b/example/alexnet.cpp
@@ -235,10 +235,10 @@ int main(int argc, char const *argv[]) {
                       .SetParam("batch_size", batch_size)
                       .CreateDataIter();
 
-  Optimizer opt("ccsgd", learning_rate, weight_decay);
-  opt.SetParam("momentum", 0.9)
-      .SetParam("rescale_grad", 1.0 / batch_size)
-      .SetParam("clip_gradient", 10);
+  Optimizer* opt = OptimizerRegistry::Find("ccsgd");
+  opt->SetParam("momentum", 0.9)
+     ->SetParam("rescale_grad", 1.0 / batch_size)
+     ->SetParam("clip_gradient", 10);
 
   Accuracy acu_train, acu_val;
   LogLoss logloss_val;
@@ -256,7 +256,7 @@ int main(int argc, char const *argv[]) {
       batch.label.CopyTo(&args_map["label"]);
       exec->Forward(true);
       exec->Backward();
-      exec->UpdateAll(&opt, learning_rate, weight_decay);
+      exec->UpdateAll(opt, learning_rate, weight_decay);
       NDArray::WaitAll();
       acu_train.Update(batch.label, exec->outputs[0]);
     }

--- a/example/googlenet.cpp
+++ b/example/googlenet.cpp
@@ -42,7 +42,8 @@ Symbol InceptionFactory(Symbol data, int num_1x1, int num_3x3red,
                              Shape(1, 1), Shape(2, 2), name + "_5x5");
 
   Symbol pooling = Pooling(name + "_pool", data, Shape(3, 3), pool,
-                           false, Shape(1, 1), Shape(1, 1));
+                           false, PoolingPoolingConvention::valid,
+                           Shape(1, 1), Shape(1, 1));
 
   Symbol cproj = ConvFactory(pooling, proj, Shape(1, 1),
                              Shape(1, 1), Shape(0, 0), name + "_proj");
@@ -62,27 +63,27 @@ Symbol GoogleNetSymbol(int num_classes) {
 
   Symbol conv1 = ConvFactory(data, 64, Shape(7, 7), Shape(2, 2), Shape(3, 3), "conv1");
   Symbol pool1 = Pooling("pool1", conv1, Shape(3, 3), PoolingPoolType::max,
-                         false, Shape(2, 2));
+                         false, PoolingPoolingConvention::valid, Shape(2, 2));
   Symbol conv2 = ConvFactory(pool1, 64, Shape(1, 1), Shape(1, 1),
                              Shape(0, 0), "conv2");
   Symbol conv3 = ConvFactory(conv2, 192, Shape(3, 3), Shape(1, 1), Shape(1, 1), "conv3");
   Symbol pool3 = Pooling("pool3", conv3, Shape(3, 3), PoolingPoolType::max,
-                         false, Shape(2, 2));
+                         false, PoolingPoolingConvention::valid, Shape(2, 2));
 
   Symbol in3a = InceptionFactory(pool3, 64, 96, 128, 16, 32, PoolingPoolType::max, 32, "in3a");
   Symbol in3b = InceptionFactory(in3a, 128, 128, 192, 32, 96, PoolingPoolType::max, 64, "in3b");
   Symbol pool4 = Pooling("pool4", in3b, Shape(3, 3), PoolingPoolType::max,
-                         false, Shape(2, 2));
+                         false, PoolingPoolingConvention::valid, Shape(2, 2));
   Symbol in4a = InceptionFactory(pool4, 192, 96, 208, 16, 48, PoolingPoolType::max, 64, "in4a");
   Symbol in4b = InceptionFactory(in4a, 160, 112, 224, 24, 64, PoolingPoolType::max, 64, "in4b");
   Symbol in4c = InceptionFactory(in4b, 128, 128, 256, 24, 64, PoolingPoolType::max, 64, "in4c");
   Symbol in4d = InceptionFactory(in4c, 112, 144, 288, 32, 64, PoolingPoolType::max, 64, "in4d");
   Symbol in4e = InceptionFactory(in4d, 256, 160, 320, 32, 128, PoolingPoolType::max, 128, "in4e");
   Symbol pool5 = Pooling("pool5", in4e, Shape(3, 3), PoolingPoolType::max,
-                         false, Shape(2, 2));
+                         false, PoolingPoolingConvention::valid, Shape(2, 2));
   Symbol in5a = InceptionFactory(pool5, 256, 160, 320, 32, 128, PoolingPoolType::max, 128, "in5a");
   Symbol in5b = InceptionFactory(in5a, 384, 192, 384, 48, 128, PoolingPoolType::max, 128, "in5b");
-  Symbol pool6 = Pooling("pool6", in5b, Shape(7, 7), PoolingPoolType::avg, false, Shape(1, 1));
+  Symbol pool6 = Pooling("pool6", in5b, Shape(7, 7), PoolingPoolType::avg, false, PoolingPoolingConvention::valid, Shape(1, 1));
 
   Symbol flatten = Flatten("flatten", pool6);
 

--- a/example/googlenet.cpp
+++ b/example/googlenet.cpp
@@ -83,7 +83,8 @@ Symbol GoogleNetSymbol(int num_classes) {
                          false, PoolingPoolingConvention::valid, Shape(2, 2));
   Symbol in5a = InceptionFactory(pool5, 256, 160, 320, 32, 128, PoolingPoolType::max, 128, "in5a");
   Symbol in5b = InceptionFactory(in5a, 384, 192, 384, 48, 128, PoolingPoolType::max, 128, "in5b");
-  Symbol pool6 = Pooling("pool6", in5b, Shape(7, 7), PoolingPoolType::avg, false, PoolingPoolingConvention::valid, Shape(1, 1));
+  Symbol pool6 = Pooling("pool6", in5b, Shape(7, 7), PoolingPoolType::avg,
+      false, PoolingPoolingConvention::valid, Shape(1, 1));
 
   Symbol flatten = Flatten("flatten", pool6);
 
@@ -122,10 +123,10 @@ int main(int argc, char const *argv[]) {
       .SetParam("batch_size", batch_size)
       .CreateDataIter();
 
-  Optimizer opt("ccsgd", learning_rate, weight_decay);
-  opt.SetParam("momentum", 0.9)
-      .SetParam("rescale_grad", 1.0 / batch_size)
-      .SetParam("clip_gradient", 10);
+  Optimizer* opt = OptimizerRegistry::Find("ccsgd");
+  opt->SetParam("momentum", 0.9)
+     ->SetParam("rescale_grad", 1.0 / batch_size)
+     ->SetParam("clip_gradient", 10);
 
   for (int iter = 0; iter < max_epoch; ++iter) {
     LG << "Epoch: " << iter;
@@ -138,7 +139,7 @@ int main(int argc, char const *argv[]) {
       auto *exec = googlenet.SimpleBind(Context::gpu(), args_map);
       exec->Forward(true);
       exec->Backward();
-      exec->UpdateAll(&opt, learning_rate, weight_decay);
+      exec->UpdateAll(opt, learning_rate, weight_decay);
       delete exec;
     }
 

--- a/example/inception_bn.cpp
+++ b/example/inception_bn.cpp
@@ -41,6 +41,7 @@ Symbol InceptionFactoryA(Symbol data, int num_1x1, int num_3x3red,
                         Shape(1, 1), name + "_double_3x3_1");
   Symbol pooling = Pooling(name + "_pool", data,
                            Shape(3, 3), pool, false,
+                           PoolingPoolingConvention::valid,
                            Shape(1, 1), Shape(1, 1));
   Symbol cproj = ConvFactoryBN(pooling, proj, Shape(1, 1), Shape(1, 1),
                                Shape(0, 0), name + "_proj");
@@ -67,7 +68,7 @@ Symbol InceptionFactoryB(Symbol data, int num_3x3red, int num_3x3,
                         Shape(1, 1), name + "_double_3x3_1");
   Symbol pooling = Pooling("max_pool_" + name + "_pool", data,
                            Shape(3, 3), PoolingPoolType::max,
-                           false, Shape(2, 2));
+                           false, PoolingPoolingConvention::valid, Shape(2, 2));
   std::vector<Symbol> lst;
   lst.push_back(c3x3);
   lst.push_back(cd3x3);
@@ -82,12 +83,14 @@ Symbol InceptionSymbol(int num_classes) {
 
   // stage 1
   Symbol conv1 = ConvFactoryBN(data, 64, Shape(7, 7), Shape(2, 2), Shape(3, 3), "conv1");
-  Symbol pool1 = Pooling("pool1", conv1, Shape(3, 3), PoolingPoolType::max, false, Shape(2, 2));
+  Symbol pool1 = Pooling("pool1", conv1, Shape(3, 3), PoolingPoolType::max,
+      false, PoolingPoolingConvention::valid, Shape(2, 2));
 
   // stage 2
   Symbol conv2red = ConvFactoryBN(pool1, 64, Shape(1, 1), Shape(1, 1),  Shape(0, 0), "conv2red");
   Symbol conv2 = ConvFactoryBN(conv2red, 192, Shape(3, 3), Shape(1, 1), Shape(1, 1), "conv2");
-  Symbol pool2 = Pooling("pool2", conv2, Shape(3, 3), PoolingPoolType::max, false, Shape(2, 2));
+  Symbol pool2 = Pooling("pool2", conv2, Shape(3, 3), PoolingPoolType::max,
+      false, PoolingPoolingConvention::valid, Shape(2, 2));
 
   // stage 3
   Symbol in3a = InceptionFactoryA(pool2, 64, 64, 64, 64, 96, PoolingPoolType::avg, 32, "3a");

--- a/example/inception_bn.cpp
+++ b/example/inception_bn.cpp
@@ -147,10 +147,10 @@ int main(int argc, char const *argv[]) {
       .SetParam("batch_size", batch_size)
       .CreateDataIter();
 
-  Optimizer opt("ccsgd", learning_rate, weight_decay);
-  opt.SetParam("momentum", 0.9)
-      .SetParam("rescale_grad", 1.0 / batch_size)
-      .SetParam("clip_gradient", 10);
+  Optimizer* opt = OptimizerRegistry::Find("ccsgd");
+  opt->SetParam("momentum", 0.9)
+     ->SetParam("rescale_grad", 1.0 / batch_size)
+     ->SetParam("clip_gradient", 10);
 
   auto *exec = inception_bn_net.SimpleBind(Context::gpu(), args_map);
 
@@ -165,7 +165,7 @@ int main(int argc, char const *argv[]) {
 
       exec->Forward(true);
       exec->Backward();
-      exec->UpdateAll(&opt, learning_rate, weight_decay);
+      exec->UpdateAll(opt, learning_rate, weight_decay);
       NDArray::WaitAll();
     }
 

--- a/example/lenet.cpp
+++ b/example/lenet.cpp
@@ -112,10 +112,10 @@ class Lenet {
     // args_map["fc1_b"] = 0;
 
     lenet.InferArgsMap(ctx_dev, &args_map, args_map);
-    Optimizer opt("ccsgd", learning_rate, weight_decay);
-    opt.SetParam("momentum", 0.9)
-        .SetParam("rescale_grad", 1.0)
-        .SetParam("clip_gradient", 10);
+    Optimizer* opt = OptimizerRegistry::Find("ccsgd");
+    opt->SetParam("momentum", 0.9)
+       ->SetParam("rescale_grad", 1.0)
+       ->SetParam("clip_gradient", 10);
 
     for (int ITER = 0; ITER < max_epoch; ++ITER) {
       size_t start_index = 0;
@@ -135,7 +135,7 @@ class Lenet {
         Executor *exe = lenet.SimpleBind(ctx_dev, args_map);
         exe->Forward(true);
         exe->Backward();
-        exe->UpdateAll(&opt, learning_rate, weight_decay);
+        exe->UpdateAll(opt, learning_rate, weight_decay);
 
         delete exe;
       }

--- a/example/lenet.cpp
+++ b/example/lenet.cpp
@@ -34,20 +34,20 @@ class Lenet {
     Symbol conv1 =
         Convolution("conv1", data, conv1_w, conv1_b, Shape(5, 5), 20);
     Symbol tanh1 = Activation("tanh1", conv1, ActivationActType::tanh);
-    Symbol pool1 = Pooling("pool1", tanh1, Shape(2, 2),
-      PoolingPoolType::max, false, Shape(2, 2));
+    Symbol pool1 = Pooling("pool1", tanh1, Shape(2, 2), PoolingPoolType::max,
+      false, PoolingPoolingConvention::valid, Shape(2, 2));
 
     Symbol conv2 = Convolution("conv2", pool1, conv2_w, conv2_b,
       Shape(5, 5), 50);
     Symbol tanh2 = Activation("tanh2", conv2, ActivationActType::tanh);
-    Symbol pool2 = Pooling("pool2", tanh2, Shape(2, 2),
-      PoolingPoolType::max, false, Shape(2, 2));
+    Symbol pool2 = Pooling("pool2", tanh2, Shape(2, 2), PoolingPoolType::max,
+      false, PoolingPoolingConvention::valid, Shape(2, 2));
 
     Symbol conv3 = Convolution("conv3", pool2, conv3_w, conv3_b,
       Shape(2, 2), 500);
     Symbol tanh3 = Activation("tanh3", conv3, ActivationActType::tanh);
-    Symbol pool3 = Pooling("pool3", tanh3, Shape(2, 2),
-      PoolingPoolType::max, false, Shape(1, 1));
+    Symbol pool3 = Pooling("pool3", tanh3, Shape(2, 2), PoolingPoolType::max,
+      false, PoolingPoolingConvention::valid, Shape(1, 1));
 
     Symbol flatten = Flatten("flatten", pool3);
     Symbol fc1 = FullyConnected("fc1", flatten, fc1_w, fc1_b, 500);

--- a/example/lenet_with_mxdataiter.cpp
+++ b/example/lenet_with_mxdataiter.cpp
@@ -79,9 +79,10 @@ int main(int argc, char const *argv[]) {
       .SetParam("label", "./t10k-labels-idx1-ubyte")
       .CreateDataIter();
 
-  Optimizer opt("ccsgd", learning_rate, weight_decay);
-  opt.SetParam("momentum", 0.9).SetParam("rescale_grad", 1.0).SetParam(
-      "clip_gradient", 10);
+  Optimizer* opt = OptimizerRegistry::Find("ccsgd");
+  opt->SetParam("momentum", 0.9)
+     ->SetParam("rescale_grad", 1.0)
+     ->SetParam("clip_gradient", 10);
 
   for (int iter = 0; iter < max_epoch; ++iter) {
     LG << "Epoch: " << iter;
@@ -94,7 +95,7 @@ int main(int argc, char const *argv[]) {
       auto *exec = lenet.SimpleBind(Context::gpu(), args_map);
       exec->Forward(true);
       exec->Backward();
-      exec->UpdateAll(&opt, learning_rate, weight_decay);
+      exec->UpdateAll(opt, learning_rate, weight_decay);
       delete exec;
     }
 

--- a/example/lenet_with_mxdataiter.cpp
+++ b/example/lenet_with_mxdataiter.cpp
@@ -28,13 +28,13 @@ Symbol LenetSymbol() {
 
   Symbol conv1 = Convolution("conv1", data, conv1_w, conv1_b, Shape(5, 5), 20);
   Symbol tanh1 = Activation("tanh1", conv1, ActivationActType::tanh);
-  Symbol pool1 =
-      Pooling("pool1", tanh1, Shape(2, 2), PoolingPoolType::max, false, Shape(2, 2));
+  Symbol pool1 = Pooling("pool1", tanh1, Shape(2, 2), PoolingPoolType::max,
+      false, PoolingPoolingConvention::valid, Shape(2, 2));
 
   Symbol conv2 = Convolution("conv2", pool1, conv2_w, conv2_b, Shape(5, 5), 50);
   Symbol tanh2 = Activation("tanh2", conv2, ActivationActType::tanh);
-  Symbol pool2 =
-      Pooling("pool2", tanh2, Shape(2, 2), PoolingPoolType::max, false, Shape(2, 2));
+  Symbol pool2 = Pooling("pool2", tanh2, Shape(2, 2), PoolingPoolType::max,
+      false, PoolingPoolingConvention::valid, Shape(2, 2));
 
   Symbol flatten = Flatten("flatten", pool2);
   Symbol fc1 = FullyConnected("fc1", flatten, fc1_w, fc1_b, 500);

--- a/example/resnet.cpp
+++ b/example/resnet.cpp
@@ -150,10 +150,10 @@ int main(int argc, char const *argv[]) {
       .SetParam("batch_size", batch_size)
       .CreateDataIter();
 
-  Optimizer opt("ccsgd", learning_rate, weight_decay);
-  opt.SetParam("momentum", 0.9)
-      .SetParam("rescale_grad", 1.0 / batch_size)
-      .SetParam("clip_gradient", 10);
+  Optimizer* opt = OptimizerRegistry::Find("ccsgd");
+  opt->SetParam("momentum", 0.9)
+     ->SetParam("rescale_grad", 1.0 / batch_size)
+     ->SetParam("clip_gradient", 10);
 
   auto *exec = resnet.SimpleBind(Context::gpu(), args_map);
 
@@ -168,7 +168,7 @@ int main(int argc, char const *argv[]) {
 
       exec->Forward(true);
       exec->Backward();
-      exec->UpdateAll(&opt, learning_rate, weight_decay);
+      exec->UpdateAll(opt, learning_rate, weight_decay);
       NDArray::WaitAll();
     }
 

--- a/include/mxnet-cpp/CPPLINT.cfg
+++ b/include/mxnet-cpp/CPPLINT.cfg
@@ -1,0 +1,2 @@
+filter=-runtime/references
+exclude_files=op.h

--- a/include/mxnet-cpp/base.h
+++ b/include/mxnet-cpp/base.h
@@ -10,6 +10,7 @@
 
 #include <cstdlib>
 #include "mxnet-cpp/c_api.h"
+#include "mxnet-cpp/nnvm_c_api.h"
 
 namespace mxnet {
 namespace cpp {

--- a/include/mxnet-cpp/c_api.h
+++ b/include/mxnet-cpp/c_api.h
@@ -6,26 +6,38 @@
 #ifndef MXNET_C_API_H_
 #define MXNET_C_API_H_
 
+/*! \brief Inhibit C++ name-mangling for MXNet functions. */
 #ifdef __cplusplus
-#define MXNET_EXTERN_C extern "C"
-#endif
+extern "C" {
+#endif  // __cplusplus
+
+/*! \brief Keep the default value in C++ */
+#ifdef __cplusplus
+#define DEFAULT(x) = x
+#else
+#define DEFAULT(x)
+#endif  // __cplusplus
 
 #include <stdint.h>
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
 
 /*! \brief MXNET_DLL prefix for windows */
 #ifdef _WIN32
 #ifdef MXNET_EXPORTS
-#define MXNET_DLL MXNET_EXTERN_C __declspec(dllexport)
+#define MXNET_DLL __declspec(dllexport)
 #else
-#define MXNET_DLL MXNET_EXTERN_C __declspec(dllimport)
+#define MXNET_DLL __declspec(dllimport)
 #endif
 #else
-#define MXNET_DLL MXNET_EXTERN_C
+#define MXNET_DLL
 #endif
 
 /*! \brief manually define unsigned int */
 typedef unsigned int mx_uint;
-/*! \brief manually define unsigned int */
+/*! \brief manually define float */
 typedef float mx_float;
 // all the handles are simply void *
 // will be casted internally to specific pointers types
@@ -52,16 +64,11 @@ typedef void *KVStoreHandle;
 typedef void *RecordIOHandle;
 /*! \brief handle to MXRtc*/
 typedef void *RtcHandle;
-/*! \brief handle to a function that takes param and creates optimizer*/
-typedef void *OptimizerCreator;
-/*! \brief handle to Optimizer*/
-typedef void *OptimizerHandle;
 
-MXNET_EXTERN_C typedef void (*ExecutorMonitorCallback)(const char*,
-                                                       NDArrayHandle,
-                                                       void *);
+typedef void (*ExecutorMonitorCallback)(const char*,
+                                        NDArrayHandle,
+                                        void *);
 
-MXNET_EXTERN_C {
 struct NativeOpInfo {
   void (*forward)(int, float**, int*, unsigned**, int*, void*);
   void (*backward)(int, float**, int*, unsigned**, int*, void*);
@@ -92,7 +99,46 @@ struct NDArrayOpInfo {
   void* p_list_arguments;
   void* p_declare_backward_dependency;
 };
-}
+
+struct CustomOpInfo {
+  bool (*forward)(int /*size*/, void** /*ptrs*/, int* /*tags*/,
+                  const int* /*reqs*/, const bool /*is_train*/, void* /*state*/);
+  bool (*backward)(int /*size*/, void** /*ptrs*/, int* /*tags*/,
+                   const int* /*reqs*/, const bool /*is_train*/, void* /*state*/);
+  bool (*del)(void* /*state*/);
+  // all functions also pass a payload void* pointer
+  void* p_forward;
+  void* p_backward;
+  void* p_del;
+};
+
+struct CustomOpPropInfo {
+  bool (*list_arguments)(char*** /*args*/, void* /*state*/);
+  bool (*list_outputs)(char*** /*outputs*/, void* /*state*/);
+  bool (*infer_shape)(int /*num_input*/, int* /*ndims*/, unsigned** /*shapes*/,
+                      void* /*state*/);
+  bool (*declare_backward_dependency)(const int* /*out_grad*/, const int* /*in_data*/,
+                                      const int* /*out_data*/, int* /*num_deps*/,
+                                      int** /*rdeps*/, void* /*state*/);
+  bool (*create_operator)(const char* /*ctx*/, int /*num_inputs*/, unsigned** /*shapes*/,
+                          int* /*ndims*/, int* /*dtypes*/,
+                          struct CustomOpInfo* /*ret*/, void* /*state*/);
+  bool (*list_auxiliary_states)(char*** /*aux*/, void* /*state*/);
+  bool (*del)(void* /*state*/);
+  // all functions also pass a payload void* pointer
+  void* p_list_arguments;
+  void* p_list_outputs;
+  void* p_infer_shape;
+  void* p_declare_backward_dependency;
+  void* p_create_operator;
+  void* p_list_auxiliary_states;
+  void* p_del;
+};
+
+typedef bool (*CustomOpPropCreator)(const char* /*op_type*/, const int /*num_kwargs*/,
+                                    const char** /*keys*/, const char** /*values*/,
+                                    struct CustomOpPropInfo* /*ret*/);
+
 /*!
  * \brief return str message of the last error
  *  all function in this file will return 0 when success
@@ -121,6 +167,24 @@ MXNET_DLL int MXRandomSeed(int seed);
  * \return 0 when success, -1 when failure happens.
  */
 MXNET_DLL int MXNotifyShutdown();
+/*!
+ * \brief Set up configuration of profiler
+ * \param mode indicate the working mode of profiler,
+ *  record anly symbolic operator when mode == 0,
+ *  record all operator when mode == 1
+ * \param filename where to save trace file
+ * \return 0 when success, -1 when failure happens.
+ */
+MXNET_DLL int MXSetProfilerConfig(int mode, const char* filename);
+/*!
+ * \brief Set up state of profiler
+ * \param state indicate the working state of profiler,
+ *  profiler not running when state == 0,
+ *  profiler running when state == 1
+ * \return 0 when success, -1 when failure happens.
+ */
+MXNET_DLL int MXSetProfilerState(int state);
+
 //-------------------------------------
 // Part 1: NDArray creation and deletion
 //-------------------------------------
@@ -271,7 +335,7 @@ MXNET_DLL int MXNDArrayWaitAll();
 MXNET_DLL int MXNDArrayFree(NDArrayHandle handle);
 /*!
  * \brief Slice the NDArray along axis 0.
- * \param handle the handle to the narraya
+ * \param handle the handle to the NDArray
  * \param slice_begin The beginning index of slice
  * \param slice_end The ending index of slice
  * \param out The NDArrayHandle of sliced NDArray
@@ -281,6 +345,16 @@ MXNET_DLL int MXNDArraySlice(NDArrayHandle handle,
                              mx_uint slice_begin,
                              mx_uint slice_end,
                              NDArrayHandle *out);
+/*!
+ * \brief Index the NDArray along axis 0.
+ * \param handle the handle to the NDArray
+ * \param idx the index
+ * \param out The NDArrayHandle of output NDArray
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXNDArrayAt(NDArrayHandle handle,
+                          mx_uint idx,
+                          NDArrayHandle *out);
 /*!
  * \brief Reshape the NDArray.
  * \param handle the handle to the narray
@@ -357,7 +431,7 @@ MXNET_DLL int MXGetFunction(const char *name,
  * \param description The returned description of the function.
  * \param num_args Number of arguments.
  * \param arg_names Name of the arguments.
- * \param arg_type_infos Type informations about the arguments.
+ * \param arg_type_infos Type information about the arguments.
  * \param arg_descriptions Description information about the arguments.
  * \param return_type Return type of the function.
  * \return 0 when success, -1 when failure happens
@@ -369,7 +443,7 @@ MXNET_DLL int MXFuncGetInfo(FunctionHandle fun,
                             const char ***arg_names,
                             const char ***arg_type_infos,
                             const char ***arg_descriptions,
-                            const char **return_type = NULL);
+                            const char **return_type DEFAULT(NULL));
 /*!
  * \brief get the argument requirements of the function
  * \param fun input function handle
@@ -419,9 +493,38 @@ MXNET_DLL int MXFuncInvokeEx(FunctionHandle fun,
                              int num_params,
                              char **param_keys,
                              char **param_vals);
+/*!
+ * \brief invoke a nnvm op and imperative function
+ * \param creator the op
+ * \param num_inputs number of input NDArrays
+ * \param inputs input NDArrays
+ * \param num_outputs number of output NDArrays
+ * \param outputs output NDArrays
+ * \param num_params number of keyword parameters
+ * \param param_keys keys for keyword parameters
+ * \param param_vals values for keyword parameters
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXImperativeInvoke(AtomicSymbolCreator creator,
+                                 int num_inputs,
+                                 NDArrayHandle *inputs,
+                                 int *num_outputs,
+                                 NDArrayHandle **outputs,
+                                 int num_params,
+                                 const char **param_keys,
+                                 const char **param_vals);
+
 //--------------------------------------------
 // Part 3: symbolic configuration generation
 //--------------------------------------------
+/*!
+ * \brief list all the available operator names, include entries.
+ * \param out_size the size of returned array
+ * \param out_array the output operator name array.
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXListAllOpNames(mx_uint *out_size,
+                               const char ***out_array);
 /*!
  * \brief list all the available AtomicSymbolEntry
  * \param out_size the size of returned array
@@ -430,6 +533,14 @@ MXNET_DLL int MXFuncInvokeEx(FunctionHandle fun,
  */
 MXNET_DLL int MXSymbolListAtomicSymbolCreators(mx_uint *out_size,
                                                AtomicSymbolCreator **out_array);
+
+/*!
+ * \brief Get the name of an atomic symbol.
+ * \param creator the AtomicSymbolCreator.
+ * \param name The returned name of the creator.
+ */
+MXNET_DLL int MXSymbolGetAtomicSymbolName(AtomicSymbolCreator creator,
+                                          const char **name);
 /*!
  * \brief Get the detailed information about atomic symbol.
  * \param creator the AtomicSymbolCreator.
@@ -455,7 +566,7 @@ MXNET_DLL int MXSymbolGetAtomicSymbolInfo(AtomicSymbolCreator creator,
                                           const char ***arg_type_infos,
                                           const char ***arg_descriptions,
                                           const char **key_var_num_args,
-                                          const char **return_type = NULL);
+                                          const char **return_type DEFAULT(NULL));
 /*!
  * \brief Create an AtomicSymbol.
  * \param creator the AtomicSymbolCreator
@@ -577,7 +688,7 @@ MXNET_DLL int MXSymbolSetAttr(SymbolHandle symbol,
                               const char* key,
                               const char* value);
 /*!
- * \brief Get all attributes from symbol
+ * \brief Get all attributes from symbol, including all descendents.
  * \param symbol the source symbol
  * \param out_size The number of output attributes
  * \param out 2*out_size strings representing key value pairs.
@@ -586,6 +697,16 @@ MXNET_DLL int MXSymbolSetAttr(SymbolHandle symbol,
 MXNET_DLL int MXSymbolListAttr(SymbolHandle symbol,
                                mx_uint *out_size,
                                const char*** out);
+/*!
+ * \brief Get all attributes from symbol, excluding descendents.
+ * \param symbol the source symbol
+ * \param out_size The number of output attributes
+ * \param out 2*out_size strings representing key value pairs.
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXSymbolListAttrShallow(SymbolHandle symbol,
+                                      mx_uint *out_size,
+                                      const char*** out);
 /*!
  * \brief List arguments in the symbol.
  * \param symbol the symbol
@@ -792,7 +913,7 @@ MXNET_DLL int MXExecutorPrint(ExecutorHandle handle, const char **out_str);
  * \brief Executor forward method
  *
  * \param handle executor handle
- * \param is_train bool value to indicate whether the forward pass is for evaluation
+ * \param is_train int value to indicate whether the forward pass is for evaluation
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXExecutorForward(ExecutorHandle handle, int is_train);
@@ -916,7 +1037,7 @@ MXNET_DLL int MXExecutorBindEX(SymbolHandle symbol_handle,
                                mx_uint *grad_req_type,
                                mx_uint aux_states_len,
                                NDArrayHandle *aux_states,
-                               ExecutorHandle *shared_exec,
+                               ExecutorHandle shared_exec,
                                ExecutorHandle *out);
 /*!
  * \brief set a call back to notify the completion of operation
@@ -1036,6 +1157,8 @@ MXNET_DLL int MXDataIterGetLabel(DataIterHandle handle,
 MXNET_DLL int MXInitPSEnv(mx_uint num_vars,
                           const char **keys,
                           const char **vals);
+
+
 /*!
  * \brief Create a kvstore
  * \param type the type of KVStore
@@ -1179,6 +1302,16 @@ MXNET_DLL int MXKVStoreIsSchedulerNode(int *ret);
 MXNET_DLL int MXKVStoreBarrier(KVStoreHandle handle);
 
 /**
+ * \brief whether to do barrier when finalize
+ *
+ * \param handle handle to the KVStore
+ * \param barrier_before_exit whether to do barrier when kvstore finalize
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXKVStoreSetBarrierBeforeExit(KVStoreHandle handle,
+                                            const int barrier_before_exit);
+
+/**
  * \brief the prototype of a server controller
  * \param head the head of the command
  * \param body the body of the command
@@ -1213,6 +1346,21 @@ MXNET_DLL int MXKVStoreSendCommmandToServers(KVStoreHandle handle,
                                              const char* cmd_body);
 
 /**
+ * \brief Get the number of ps dead node(s) specified by {node_id}
+ *
+ * \param handle handle to the KVStore
+ * \param node_id Can be a node group or a single node.
+ *                kScheduler = 1, kServerGroup = 2, kWorkerGroup = 4
+ * \param number Ouptut number of dead nodes
+ * \param timeout_sec A node fails to send heartbeart in {timeout_sec} seconds
+ *                    will be presumed as 'dead'
+ */
+MXNET_DLL int MXKVStoreGetNumDeadNode(KVStoreHandle handle,
+                                      const int node_id,
+                                      int *number,
+                                      const int timeout_sec DEFAULT(60));
+
+/**
  * \brief Create a RecordIO writer object
  * \param uri path to file
  * \param out handle pointer to the created object
@@ -1234,8 +1382,16 @@ MXNET_DLL int MXRecordIOWriterFree(RecordIOHandle handle);
  * \param size size of buffer
  * \return 0 when success, -1 when failure happens
 */
-MXNET_DLL int MXRecordIOWriterWriteRecord(RecordIOHandle *handle,
+MXNET_DLL int MXRecordIOWriterWriteRecord(RecordIOHandle handle,
                                           const char *buf, size_t size);
+
+/**
+ * \brief Get the current writer pointer position
+ * \param handle handle to RecordIO object
+ * \param pos handle to output position
+ * \return 0 when success, -1 when failure happens
+*/
+MXNET_DLL int MXRecordIOWriterTell(RecordIOHandle handle, size_t *pos);
 
 /**
  * \brief Create a RecordIO reader object
@@ -1250,7 +1406,7 @@ MXNET_DLL int MXRecordIOReaderCreate(const char *uri, RecordIOHandle *out);
  * \param handle handle to RecordIO object
  * \return 0 when success, -1 when failure happens
 */
-MXNET_DLL int MXRecordIOReaderFree(RecordIOHandle *handle);
+MXNET_DLL int MXRecordIOReaderFree(RecordIOHandle handle);
 
 /**
  * \brief Write a record to a RecordIO object
@@ -1259,8 +1415,16 @@ MXNET_DLL int MXRecordIOReaderFree(RecordIOHandle *handle);
  * \param size point to size of buffer
  * \return 0 when success, -1 when failure happens
 */
-MXNET_DLL int MXRecordIOReaderReadRecord(RecordIOHandle *handle,
+MXNET_DLL int MXRecordIOReaderReadRecord(RecordIOHandle handle,
                                         char const **buf, size_t *size);
+
+/**
+ * \brief Set the current reader pointer position
+ * \param handle handle to RecordIO object
+ * \param pos target position
+ * \return 0 when success, -1 when failure happens
+*/
+MXNET_DLL int MXRecordIOReaderSeek(RecordIOHandle handle, size_t pos);
 
 /**
  * \brief Create a MXRtc object
@@ -1287,22 +1451,10 @@ MXNET_DLL int MXRtcPush(RtcHandle handle, mx_uint num_input, mx_uint num_output,
 */
 MXNET_DLL int MXRtcFree(RtcHandle handle);
 
-MXNET_DLL int MXOptimizerFindCreator(const char *key,
-                                     OptimizerCreator *out);
+MXNET_DLL int MXCustomOpRegister(const char* op_type, CustomOpPropCreator creator);
 
-MXNET_DLL int MXOptimizerCreateOptimizer(OptimizerCreator creator,
-                                         mx_uint num_param,
-                                         const char **keys,
-                                         const char **vals,
-                                         OptimizerHandle *out);
-
-MXNET_DLL int MXOptimizerFree(OptimizerHandle handle);
-
-MXNET_DLL int MXOptimizerUpdate(OptimizerHandle handle,
-                                int index,
-                                NDArrayHandle weight,
-                                NDArrayHandle grad,
-                                mx_float lr,
-                                mx_float wd);
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
 
 #endif  // MXNET_C_API_H_

--- a/include/mxnet-cpp/kvstore.hpp
+++ b/include/mxnet-cpp/kvstore.hpp
@@ -36,12 +36,8 @@ namespace private_ {
         size_t n = line.find('=');
         params.emplace(line.substr(0, n), line.substr(n+1));
       }
-      float lr = std::stof(params.at("learning_rate"));
-      float wd = std::stof(params.at("weight_decay"));
-      std::unique_ptr<Optimizer> opt(new Optimizer(params.at("opt_type"), lr, wd));
+      std::unique_ptr<Optimizer> opt(OptimizerRegistry::Find(params.at("opt_type")));
       params.erase("opt_type");
-      params.erase("learning_rate");
-      params.erase("weight_decay");
       for (const auto& pair : params) {
         opt->SetParam(pair.first, pair.second);
       }

--- a/include/mxnet-cpp/ndarray.hpp
+++ b/include/mxnet-cpp/ndarray.hpp
@@ -73,174 +73,84 @@ NDArray::NDArray(const std::vector<mx_float> &data) {
 
 NDArray NDArray::operator+(mx_float scalar) {
   NDArray ret;
-  static FunctionHandle func_handle;
-  MXGetFunction("_plus_scalar", &func_handle);
-  CHECK_EQ(MXFuncInvoke(func_handle, &blob_ptr_->handle_, &scalar,
-                        &ret.blob_ptr_->handle_),
-           0);
+  Operator("_plus_scalar")(*this, scalar).Invoke(ret);
   return ret;
 }
 NDArray NDArray::operator-(mx_float scalar) {
   NDArray ret;
-  static FunctionHandle func_handle;
-  MXGetFunction("_minus_scalar", &func_handle);
-  CHECK_EQ(MXFuncInvoke(func_handle, &blob_ptr_->handle_, &scalar,
-                        &ret.blob_ptr_->handle_),
-           0);
+  Operator("_minus_scalar")(*this, scalar).Invoke(ret);
   return ret;
 }
 NDArray NDArray::operator*(mx_float scalar) {
   NDArray ret;
-  static FunctionHandle func_handle;
-  MXGetFunction("_mul_scalar", &func_handle);
-  CHECK_EQ(MXFuncInvoke(func_handle, &blob_ptr_->handle_, &scalar,
-                        &ret.blob_ptr_->handle_),
-           0);
+  Operator("_mul_scalar")(*this, scalar).Invoke(ret);
   return ret;
 }
 NDArray NDArray::operator/(mx_float scalar) {
   NDArray ret;
-  static FunctionHandle func_handle;
-  MXGetFunction("_div_scalar", &func_handle);
-  CHECK_EQ(MXFuncInvoke(func_handle, &blob_ptr_->handle_, &scalar,
-                        &ret.blob_ptr_->handle_),
-           0);
+  Operator("_div_scalar")(*this, scalar).Invoke(ret);
   return ret;
 }
 NDArray NDArray::operator+(const NDArray &rhs) {
   NDArray ret;
-  static FunctionHandle func_handle;
-  MXGetFunction("_plus", &func_handle);
-  NDArrayHandle input_handle[2];
-  input_handle[0] = blob_ptr_->handle_;
-  input_handle[1] = rhs.blob_ptr_->handle_;
-  CHECK_EQ(
-      MXFuncInvoke(func_handle, input_handle, nullptr, &ret.blob_ptr_->handle_),
-      0);
+  Operator("_plus")(*this, rhs).Invoke(ret);
   return ret;
 }
 NDArray NDArray::operator-(const NDArray &rhs) {
   NDArray ret;
-  static FunctionHandle func_handle;
-  MXGetFunction("_minus", &func_handle);
-  NDArrayHandle input_handle[2];
-  input_handle[0] = blob_ptr_->handle_;
-  input_handle[1] = rhs.blob_ptr_->handle_;
-  CHECK_EQ(
-      MXFuncInvoke(func_handle, input_handle, nullptr, &ret.blob_ptr_->handle_),
-      0);
+  Operator("_minus")(*this, rhs).Invoke(ret);
   return ret;
 }
 NDArray NDArray::operator*(const NDArray &rhs) {
   NDArray ret;
-  static FunctionHandle func_handle;
-  MXGetFunction("_mul", &func_handle);
-  NDArrayHandle input_handle[2];
-  input_handle[0] = blob_ptr_->handle_;
-  input_handle[1] = rhs.blob_ptr_->handle_;
-  CHECK_EQ(
-      MXFuncInvoke(func_handle, input_handle, nullptr, &ret.blob_ptr_->handle_),
-      0);
+  Operator("_mul")(*this, rhs).Invoke(ret);
   return ret;
 }
 NDArray NDArray::operator/(const NDArray &rhs) {
   NDArray ret;
-  static FunctionHandle func_handle;
-  MXGetFunction("_div", &func_handle);
-  NDArrayHandle input_handle[2];
-  input_handle[0] = blob_ptr_->handle_;
-  input_handle[1] = rhs.blob_ptr_->handle_;
-  CHECK_EQ(
-      MXFuncInvoke(func_handle, input_handle, nullptr, &ret.blob_ptr_->handle_),
-      0);
+  Operator("_div")(*this, rhs).Invoke(ret);
   return ret;
 }
 NDArray &NDArray::operator=(mx_float scalar) {
-  static FunctionHandle func_handle;
-  MXGetFunction("_set_value", &func_handle);
-  CHECK_EQ(MXFuncInvoke(func_handle, nullptr, &scalar, &blob_ptr_->handle_), 0);
+  Operator("_set_value")(scalar).Invoke(*this);
   return *this;
 }
 NDArray &NDArray::operator+=(mx_float scalar) {
-  static FunctionHandle func_handle;
-  MXGetFunction("_plus_scalar", &func_handle);
-  CHECK_EQ(MXFuncInvoke(func_handle, &blob_ptr_->handle_, &scalar,
-                        &blob_ptr_->handle_),
-           0);
+  Operator("_plus_scalar")(*this, scalar).Invoke(*this);
   return *this;
 }
 NDArray &NDArray::operator-=(mx_float scalar) {
-  static FunctionHandle func_handle;
-  MXGetFunction("_minus_scalar", &func_handle);
-  CHECK_EQ(MXFuncInvoke(func_handle, &blob_ptr_->handle_, &scalar,
-                        &blob_ptr_->handle_),
-           0);
+  Operator("_minus_scalar")(*this, scalar).Invoke(*this);
   return *this;
 }
 NDArray &NDArray::operator*=(mx_float scalar) {
-  static FunctionHandle func_handle;
-  MXGetFunction("_mul_scalar", &func_handle);
-  CHECK_EQ(MXFuncInvoke(func_handle, &blob_ptr_->handle_, &scalar,
-                        &blob_ptr_->handle_),
-           0);
+  Operator("_mul_scalar")(*this, scalar).Invoke(*this);
   return *this;
 }
 NDArray &NDArray::operator/=(mx_float scalar) {
-  static FunctionHandle func_handle;
-  MXGetFunction("_div_scalar", &func_handle);
-  CHECK_EQ(MXFuncInvoke(func_handle, &blob_ptr_->handle_, &scalar,
-                        &blob_ptr_->handle_),
-           0);
+  Operator("_div_scalar")(*this, scalar).Invoke(*this);
   return *this;
 }
 NDArray &NDArray::operator+=(const NDArray &rhs) {
-  static FunctionHandle func_handle;
-  MXGetFunction("_plus", &func_handle);
-  NDArrayHandle input_handle[2];
-  input_handle[0] = blob_ptr_->handle_;
-  input_handle[1] = rhs.blob_ptr_->handle_;
-  CHECK_EQ(
-      MXFuncInvoke(func_handle, input_handle, nullptr, &blob_ptr_->handle_), 0);
+  Operator("_plus")(*this, rhs).Invoke(*this);
   return *this;
 }
 NDArray &NDArray::operator-=(const NDArray &rhs) {
-  static FunctionHandle func_handle;
-  MXGetFunction("_minus", &func_handle);
-  NDArrayHandle input_handle[2];
-  input_handle[0] = blob_ptr_->handle_;
-  input_handle[1] = rhs.blob_ptr_->handle_;
-  CHECK_EQ(
-      MXFuncInvoke(func_handle, input_handle, nullptr, &blob_ptr_->handle_), 0);
+  Operator("_minus")(*this, rhs).Invoke(*this);
   return *this;
 }
 NDArray &NDArray::operator*=(const NDArray &rhs) {
-  static FunctionHandle func_handle;
-  MXGetFunction("_mul", &func_handle);
-  NDArrayHandle input_handle[2];
-  input_handle[0] = blob_ptr_->handle_;
-  input_handle[1] = rhs.blob_ptr_->handle_;
-  CHECK_EQ(
-      MXFuncInvoke(func_handle, input_handle, nullptr, &blob_ptr_->handle_), 0);
+  Operator("_mul")(*this, rhs).Invoke(*this);
   return *this;
 }
 NDArray &NDArray::operator/=(const NDArray &rhs) {
-  static FunctionHandle func_handle;
-  MXGetFunction("_div", &func_handle);
-  NDArrayHandle input_handle[2];
-  input_handle[0] = blob_ptr_->handle_;
-  input_handle[1] = rhs.blob_ptr_->handle_;
-  CHECK_EQ(
-      MXFuncInvoke(func_handle, input_handle, nullptr, &blob_ptr_->handle_), 0);
+  Operator("_div")(*this, rhs).Invoke(*this);
   return *this;
 }
 
 NDArray NDArray::ArgmaxChannel() {
   NDArray ret;
-  static FunctionHandle func_handle;
-  MXGetFunction("argmax_channel", &func_handle);
-  CHECK_EQ(MXFuncInvoke(func_handle, &blob_ptr_->handle_, nullptr,
-                        &ret.blob_ptr_->handle_),
-           0);
+  Operator("argmax_channel")(*this).Invoke(ret);
   return ret;
 }
 
@@ -260,19 +170,11 @@ void NDArray::SyncCopyToCPU(std::vector<mx_float> *data, size_t size) {
 }
 NDArray NDArray::Copy(const Context &ctx) const {
   NDArray ret(GetShape(), ctx);
-  static FunctionHandle func_handle;
-  MXGetFunction("_copyto", &func_handle);
-  CHECK_EQ(MXFuncInvoke(func_handle, &blob_ptr_->handle_, nullptr,
-                        &ret.blob_ptr_->handle_),
-           0);
+  Operator("_copyto")(*this).Invoke(ret);
   return ret;
 }
 NDArray NDArray::CopyTo(NDArray * other) const {
-  static FunctionHandle func_handle;
-  MXGetFunction("_copyto", &func_handle);
-  CHECK_EQ(MXFuncInvoke(func_handle, &blob_ptr_->handle_, nullptr,
-                        &other->blob_ptr_->handle_),
-           0);
+  Operator("_copyto")(*this).Invoke(*other);
   return *other;
 }
 NDArray NDArray::Slice(mx_uint begin, mx_uint end) const {
@@ -299,18 +201,10 @@ void NDArray::WaitToWrite() {
 }
 void NDArray::WaitAll() { CHECK_EQ(MXNDArrayWaitAll(), 0); }
 void NDArray::SampleGaussian(mx_float mu, mx_float sigma, NDArray *out) {
-  static FunctionHandle func_handle;
-  MXGetFunction("_random_gaussian", &func_handle);
-  mx_float scalar[2] = {mu, sigma};
-  CHECK_EQ(MXFuncInvoke(func_handle, nullptr, scalar, &out->blob_ptr_->handle_),
-           0);
+  Operator("_sample_normal")(mu, sigma).Invoke(*out);
 }
 void NDArray::SampleUniform(mx_float begin, mx_float end, NDArray *out) {
-  static FunctionHandle func_handle;
-  MXGetFunction("_random_uniform", &func_handle);
-  mx_float scalar[2] = {begin, end};
-  CHECK_EQ(MXFuncInvoke(func_handle, nullptr, scalar, &out->blob_ptr_->handle_),
-           0);
+  Operator("_sample_uniform")(begin, end).Invoke(*out);
 }
 void NDArray::Load(const std::string &file_name,
                    std::vector<NDArray> *array_list,

--- a/include/mxnet-cpp/nnvm_c_api.h
+++ b/include/mxnet-cpp/nnvm_c_api.h
@@ -1,0 +1,368 @@
+/*!
+ *  Copyright (c) 2016 by Contributors
+ * \file c_api.h
+ * \brief C API of NNVM symbolic construction and pass.
+ *  Enables construction and transformation of Graph
+ *  in any other host languages.
+ */
+#ifndef NNVM_C_API_H_
+#define NNVM_C_API_H_
+
+#ifdef __cplusplus
+#define NNVM_EXTERN_C extern "C"
+#else
+#define NNVM_EXTERN_C
+#endif
+
+/*! \brief NNVM_DLL prefix for windows */
+#ifdef _WIN32
+#ifdef NNVM_EXPORTS
+#define NNVM_DLL NNVM_EXTERN_C __declspec(dllexport)
+#else
+#define NNVM_DLL NNVM_EXTERN_C __declspec(dllimport)
+#endif
+#else
+#define NNVM_DLL NNVM_EXTERN_C
+#endif
+
+/*! \brief manually define unsigned int */
+typedef unsigned int nn_uint;
+
+/*! \brief handle to a function that takes param and creates symbol */
+typedef void *OpHandle;
+/*! \brief handle to a symbol that can be bind as operator */
+typedef void *SymbolHandle;
+/*! \brief handle to Graph */
+typedef void *GraphHandle;
+
+/*!
+ * \brief Set the last error message needed by C API
+ * \param msg The error message to set.
+ */
+NNVM_DLL void NNAPISetLastError(const char* msg);
+
+/*!
+ * \brief return str message of the last error
+ *  all function in this file will return 0 when success
+ *  and -1 when an error occured,
+ *  NNGetLastError can be called to retrieve the error
+ *
+ *  this function is threadsafe and can be called by different thread
+ *  \return error info
+ */
+NNVM_DLL const char *NNGetLastError(void);
+
+/*!
+ * \brief list all the available operator names, include entries.
+ * \param out_size the size of returned array
+ * \param out_array the output operator name array.
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNListAllOpNames(nn_uint *out_size,
+                              const char*** out_array);
+
+/*!
+ * \brief Get operator handle given name.
+ * \param op_name The name of the operator.
+ * \param op_out The returnning op handle.
+ */
+NNVM_DLL int NNGetOpHandle(const char* op_name,
+                           OpHandle* op_out);
+
+/*!
+ * \brief list all the available operators.
+ *  This won't include the alias, use ListAllNames
+ *  instead to get all alias names.
+ *
+ * \param out_size the size of returned array
+ * \param out_array the output AtomicSymbolCreator array
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNListUniqueOps(nn_uint *out_size,
+                             OpHandle **out_array);
+
+/*!
+ * \brief Get the detailed information about atomic symbol.
+ * \param op The operator handle.
+ * \param real_name The returned name of the creator.
+ *   This name is not the alias name of the atomic symbol.
+ * \param description The returned description of the symbol.
+ * \param num_doc_args Number of arguments that contain documents.
+ * \param arg_names Name of the arguments of doc args
+ * \param arg_type_infos Type informations about the arguments.
+ * \param arg_descriptions Description information about the arguments.
+ * \param return_type Return type of the function, if any.
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNGetOpInfo(OpHandle op,
+                         const char **real_name,
+                         const char **description,
+                         nn_uint *num_doc_args,
+                         const char ***arg_names,
+                         const char ***arg_type_infos,
+                         const char ***arg_descriptions,
+                         const char **return_type);
+/*!
+ * \brief Create an AtomicSymbol functor.
+ * \param op The operator handle
+ * \param num_param the number of parameters
+ * \param keys the keys to the params
+ * \param vals the vals of the params
+ * \param out pointer to the created symbol handle
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolCreateAtomicSymbol(OpHandle op,
+                                        nn_uint num_param,
+                                        const char **keys,
+                                        const char **vals,
+                                        SymbolHandle *out);
+/*!
+ * \brief Create a Variable Symbol.
+ * \param name name of the variable
+ * \param out pointer to the created symbol handle
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolCreateVariable(const char *name, SymbolHandle *out);
+/*!
+ * \brief Create a Symbol by grouping list of symbols together
+ * \param num_symbols number of symbols to be grouped
+ * \param symbols array of symbol handles
+ * \param out pointer to the created symbol handle
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolCreateGroup(nn_uint num_symbols,
+                                 SymbolHandle *symbols,
+                                 SymbolHandle *out);
+/*!
+ * \brief Add src_dep to the handle as control dep.
+ * \param handle The symbol to add dependency edges on.
+ * \param src_dep the source handles.
+ */
+NNVM_DLL int NNAddControlDeps(SymbolHandle handle,
+                              SymbolHandle src_dep);
+/*!
+ * \brief Free the symbol handle.
+ * \param symbol the symbol
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolFree(SymbolHandle symbol);
+/*!
+ * \brief Copy the symbol to another handle
+ * \param symbol the source symbol
+ * \param out used to hold the result of copy
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolCopy(SymbolHandle symbol, SymbolHandle *out);
+/*!
+ * \brief Print the content of symbol, used for debug.
+ * \param symbol the symbol
+ * \param out_str pointer to hold the output string of the printing.
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolPrint(SymbolHandle symbol, const char **out_str);
+/*!
+ * \brief Get string attribute from symbol
+ * \param symbol the source symbol
+ * \param key The key of the symbol.
+ * \param out The result attribute, can be NULL if the attribute do not exist.
+ * \param success Whether the result is contained in out.
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolGetAttr(SymbolHandle symbol,
+                             const char* key,
+                             const char** out,
+                             int *success);
+/*!
+ * \brief Set string attribute from symbol.
+ *  NOTE: Setting attribute to a symbol can affect the semantics(mutable/immutable) of symbolic graph.
+ *
+ *  Safe recommendaton: use  immutable graph
+ *  - Only allow set attributes during creation of new symbol as optional parameter
+ *
+ *  Mutable graph (be careful about the semantics):
+ *  - Allow set attr at any point.
+ *  - Mutating an attribute of some common node of two graphs can cause confusion from user.
+ *
+ * \param symbol the source symbol
+ * \param num_param Number of parameters to set.
+ * \param keys The keys of the attribute
+ * \param values The value to be set
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolSetAttrs(SymbolHandle symbol,
+                              nn_uint num_param,
+                              const char** keys,
+                              const char** values);
+/*!
+ * \brief Get all attributes from symbol, including all descendents.
+ * \param symbol the source symbol
+ * \param recursive_option 0 for recursive, 1 for shallow.
+ * \param out_size The number of output attributes
+ * \param out 2*out_size strings representing key value pairs.
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolListAttrs(SymbolHandle symbol,
+                               int recursive_option,
+                               nn_uint *out_size,
+                               const char*** out);
+
+/*!
+ * \brief List inputs variables in the symbol.
+ * \param symbol the symbol
+ * \param option The option to list the inputs
+ *   option=0 means list all arguments.
+ *   option=1 means list arguments that are readed only by the graph.
+ *   option=2 means list arguments that are mutated by the graph.
+ * \param out_size output size
+ * \param out_sym_array the output array.
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolListInputVariables(SymbolHandle symbol,
+                                        int option,
+                                        nn_uint *out_size,
+                                        SymbolHandle** out_sym_array);
+
+/*!
+ * \brief List input names in the symbol.
+ * \param symbol the symbol
+ * \param option The option to list the inputs
+ *   option=0 means list all arguments.
+ *   option=1 means list arguments that are readed only by the graph.
+ *   option=2 means list arguments that are mutated by the graph.
+ * \param out_size output size
+ * \param out_str_array pointer to hold the output string array
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolListInputNames(SymbolHandle symbol,
+                                    int option,
+                                    nn_uint *out_size,
+                                    const char ***out_str_array);
+/*!
+ * \brief List returns names in the symbol.
+ * \param symbol the symbol
+ * \param out_size output size
+ * \param out_str_array pointer to hold the output string array
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolListOutputNames(SymbolHandle symbol,
+                                     nn_uint *out_size,
+                                     const char ***out_str_array);
+/*!
+ * \brief Get a symbol that contains all the internals.
+ * \param symbol The symbol
+ * \param out The output symbol whose outputs are all the internals.
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolGetInternals(SymbolHandle symbol,
+                                  SymbolHandle *out);
+/*!
+ * \brief Get index-th outputs of the symbol.
+ * \param symbol The symbol
+ * \param index the Index of the output.
+ * \param out The output symbol whose outputs are the index-th symbol.
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolGetOutput(SymbolHandle symbol,
+                               nn_uint index,
+                               SymbolHandle *out);
+
+/*!
+ * \brief Compose the symbol on other symbols.
+ *
+ *  This function will change the sym hanlde.
+ *  To achieve function apply behavior, copy the symbol first
+ *  before apply.
+ *
+ * \param sym the symbol to apply
+ * \param name the name of symbol
+ * \param num_args number of arguments
+ * \param keys the key of keyword args (optional)
+ * \param args arguments to sym
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolCompose(SymbolHandle sym,
+                             const char* name,
+                             nn_uint num_args,
+                             const char** keys,
+                             SymbolHandle* args);
+
+// Graph IR API
+/*!
+ * \brief create a graph handle from symbol
+ * \param symbol The symbol representing the graph.
+ * \param graph The graph handle created.
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNGraphCreate(SymbolHandle symbol, GraphHandle *graph);
+/*!
+ * \brief free the graph handle
+ * \param handle The handle to be freed.
+ */
+NNVM_DLL int NNGraphFree(GraphHandle handle);
+/*!
+ * \brief Get a new symbol from the graph.
+ * \param graph The graph handle.
+ * \param symbol The corresponding symbol
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNGraphGetSymbol(GraphHandle graph, SymbolHandle *symbol);
+
+/*!
+ * \brief Get Set a attribute in json format.
+ * This feature allows pass graph attributes back and forth in reasonable speed.
+ *
+ * \param handle The graph handle.
+ * \param key The key to the attribute.
+ * \param json_value The value need to be in format [type_name, value],
+ *  Where type_name is a registered type string in C++ side via DMLC_JSON_ENABLE_ANY.
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNGraphSetJSONAttr(GraphHandle handle,
+                                const char* key,
+                                const char* json_value);
+
+/*!
+ * \brief Get a serialized attrirbute from graph.
+ * This feature allows pass graph attributes back and forth in reasonable speed.
+ *
+ * \param handle The graph handle.
+ * \param key The key to the attribute.
+ * \param json_out The result attribute, can be NULL if the attribute do not exist.
+ *  The json_out is an array of [type_name, value].
+ *  Where the type_name is a registered type string in C++ side via DMLC_JSON_ENABLE_ANY.
+ * \param success Whether the result is contained in out.
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNGraphGetJSONAttr(SymbolHandle handle,
+                                const char* key,
+                                const char** json_out,
+                                int *success);
+
+/*!
+ * \brief Set a attribute whose type is std::vector<NodeEntry> in c++
+ * This feature allows pass List of symbolic variables for gradient request.
+ *
+ * \note This is beta feature only used for test purpos
+ *
+ * \param handle The graph handle.
+ * \param key The key to the attribute.
+ * \param list The symbol whose outputs represents the list of NodeEntry to be passed.
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNGraphSetNodeEntryListAttr_(GraphHandle handle,
+                                          const char* key,
+                                          SymbolHandle list);
+/*!
+ * \brief Apply passes on the src graph.
+ * \param src The source graph handle.
+ * \param num_pass The number of pass to be applied.
+ * \param pass_names The names of the pass.
+ * \param dst The result graph.
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNGraphApplyPasses(GraphHandle src,
+                                nn_uint num_pass,
+                                const char** pass_names,
+                                GraphHandle *dst);
+
+#endif  // NNVM_C_API_H_

--- a/include/mxnet-cpp/op.h
+++ b/include/mxnet-cpp/op.h
@@ -18,6 +18,396 @@ namespace mxnet {
 namespace cpp {
 
 /*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_add(const std::string& symbol_name,
+                            Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_add")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_sub(const std::string& symbol_name,
+                            Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_sub")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_mul(const std::string& symbol_name,
+                            Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_mul")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_div(const std::string& symbol_name,
+                            Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_div")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Reshape input according to a target shape spec.
+ *        The target shape is a tuple and can be a simple list of dimensions
+ *        such as (12,3) or it can incorporate special codes that correspond
+ *        The special codes are all expressed as integers less than 1. These
+ *        codes effectively refer to a machine that pops input dims off the
+ *        beginning of the input dims list and pushes resulting output dims
+ *        onto the end of the output dims list, which starts empty. The codes
+ *        0  Copy     Pop one input dim and push it onto the output dims
+ *        -1  Infer    Push a dim that is inferred later from all other output
+ *        -2  CopyAll  Pop all remaining input dims and push them onto output
+ *        -3  Merge2   Pop two input dims, multiply them, and push result
+ *        -4  Split2   Pop one input dim, and read two next target shape specs,
+ *        push them both onto output dims (either can be -1 and will
+ *        be inferred from the other
+ *        The exact mathematical behavior of these codes is given in the
+ *        description of the 'shape' parameter. All non-codes (positive
+ *        integers) just pop a dim off the input dims (if any), throw it away,
+ *        Examples:
+ *        Type     Input      Target            Output
+ *        Copy     (2,3,4)    (4,0,2)           (4,3,2)
+ *        Copy     (2,3,4)    (2,0,0)           (2,3,4)
+ *        Infer    (2,3,4)    (6,1,-1)          (6,1,4)
+ *        Infer    (2,3,4)    (3,-1,8)          (3,1,8)
+ *        CopyAll  (9,8,7)    (-2)              (9,8,7)
+ *        CopyAll  (9,8,7)    (9,-2)            (9,8,7)
+ *        CopyAll  (9,8,7)    (-2,1,1)          (9,8,7,1,1)
+ *        Merge2   (3,4)      (-3)              (12)
+ *        Merge2   (3,4,5)    (-3,0)            (12,5)
+ *        Merge2   (3,4,5)    (0,-3)            (3,20)
+ *        Merge2   (3,4,5,6)  (-3,0,0)          (12,5,6)
+ *        Merge2   (3,4,5,6)  (-3,-2)           (12,5,6)
+ *        Split2   (12)       (-4,6,2)          (6,2)
+ *        Split2   (12)       (-4,2,6)          (2,6)
+ *        Split2   (12)       (-4,-1,6)         (2,6)
+ *        Split2   (12,9)     (-4,2,6,0)        (2,6,9)
+ *        Split2   (12,9,9,9) (-4,2,6,-2)       (2,6,9,9,9)
+ *        Split2   (12,12)    (-4,2,-1,-4,-1,2) (2,6,6,2)
+ *
+ *
+ *        From:src/operator/tensor/matrix_op.cc:61
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to reshape.
+ * \param target_shape (Deprecated! Use shape instead.) Target new shape. One
+ *        and only one dim can be 0, in which case it will be inferred from
+ * \param keep_highest (Deprecated! Use shape instead.) Whether keep the
+ *        highest dim unchanged.If set to true, then the first dim in
+ * \param shape Target shape, a tuple, t=(t_1,t_2,..,t_m).
+ *        Let the input dims be s=(s_1,s_2,..,s_n).
+ *        The output dims u=(u_1,u_2,..,u_p) are computed from s and t.
+ *        The target shape tuple elements t_i are read in order, and used to
+ *        t_i:       meaning:      behavior:
+ *        +ve        explicit      u_p = t_i
+ *        0          copy          u_p = s_i
+ *        -1         infer         u_p = (Prod s_i) / (Prod u_j | j != p)
+ *        -2         copy all      u_p = s_i, u_p+1 = s_i+1, ...
+ *        -3         merge two     u_p = s_i * s_i+1
+ *        -4,a,b     split two     u_p = a, u_p+1 = b | a * b = s_i
+ *        The split directive (-4) in the target shape tuple is followed by two
+ *        dimensions, one of which can be -1, which means it will be inferred
+ *        The can only be one globally inferred dimension (-1), aside from any
+ * \param reverse Whether to match the shapes from the backward. If reverse is
+ *        true, 0 values in the `shape` argument will be searched from the
+ *        backward. E.g the original shape is (10, 5, 4) and the shape
+ *        argument is (-1, 0). If reverse is true, the new shape should be
+ * \return new symbol
+ */
+inline Symbol Reshape(const std::string& symbol_name,
+                      Symbol data,
+                      Shape target_shape = Shape(0,0),
+                      bool keep_highest = false,
+                      Shape shape = Shape(),
+                      bool reverse = false) {
+  return Operator("Reshape")
+           .SetParam("target_shape", target_shape)
+           .SetParam("keep_highest", keep_highest)
+           .SetParam("shape", shape)
+           .SetParam("reverse", reverse)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Flatten input into 2D by collapsing all the higher dimensions.
+ *        A (d1, d2, ..., dK) tensor is flatten to (d1, d2* ... *dK) matrix.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to reshape.
+ * \return new symbol
+ */
+inline Symbol Flatten(const std::string& symbol_name,
+                      Symbol data) {
+  return Operator("Flatten")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Transpose the input tensor and return a new one
+ *
+ *        From:src/operator/tensor/matrix_op.cc:93
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axes Target axis order. By default the axes will be inverted.
+ * \return new symbol
+ */
+inline Symbol transpose(const std::string& symbol_name,
+                        Symbol data,
+                        Shape axes = Shape()) {
+  return Operator("transpose")
+           .SetParam("axes", axes)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Expand the shape of array by inserting a new axis.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:121
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axis Position (amongst axes) where new axis is to be inserted.
+ * \return new symbol
+ */
+inline Symbol expand_dims(const std::string& symbol_name,
+                          Symbol data,
+                          int axis) {
+  return Operator("expand_dims")
+           .SetParam("axis", axis)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif (Crop the input tensor and return a new one.
+ *
+ *        Requirements
+ *        ------------
+ *        - the input and output (if explicitly given) are of the same data
+ *        and on the same device.
+ *        )
+ *
+ *        From:src/operator/tensor/matrix_op.cc:142
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param begin starting coordinates
+ * \param end ending coordinates
+ * \return new symbol
+ */
+inline Symbol crop(const std::string& symbol_name,
+                   Symbol data,
+                   Shape begin,
+                   Shape end) {
+  return Operator("crop")
+           .SetParam("begin", begin)
+           .SetParam("end", end)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Slice the input along certain axis and return a sliced array.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:197
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axis The axis to be sliced
+ * \param begin The beginning index to be sliced
+ * \param end The end index to be sliced
+ * \return new symbol
+ */
+inline Symbol slice_axis(const std::string& symbol_name,
+                         Symbol data,
+                         int axis,
+                         int begin,
+                         int end) {
+  return Operator("slice_axis")
+           .SetParam("axis", axis)
+           .SetParam("begin", begin)
+           .SetParam("end", end)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Flip the input tensor along axis and return a new one.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:216
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axis The dimension to flip
+ * \return new symbol
+ */
+inline Symbol flip(const std::string& symbol_name,
+                   Symbol data,
+                   int axis) {
+  return Operator("flip")
+           .SetParam("axis", axis)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Calculate dot product of two matrices or two vectors.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:228
+ * \param symbol_name name of the resulting symbol
+ * \param lhs Left input
+ * \param rhs Right input
+ * \param transpose_a True if the first matrix is transposed.
+ * \param transpose_b True if the second matrix is tranposed.
+ * \return new symbol
+ */
+inline Symbol dot(const std::string& symbol_name,
+                  Symbol lhs,
+                  Symbol rhs,
+                  bool transpose_a = false,
+                  bool transpose_b = false) {
+  return Operator("dot")
+           .SetParam("transpose_a", transpose_a)
+           .SetParam("transpose_b", transpose_b)
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Calculate batched dot product of two matrices. (batch, M, K)
+ *
+ *        From:src/operator/tensor/matrix_op.cc:254
+ * \param symbol_name name of the resulting symbol
+ * \param lhs Left input
+ * \param rhs Right input
+ * \param axis The dimension to flip
+ * \return new symbol
+ */
+inline Symbol batch_dot(const std::string& symbol_name,
+                        Symbol lhs,
+                        Symbol rhs,
+                        int axis) {
+  return Operator("batch_dot")
+           .SetParam("axis", axis)
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol elemwise_add(const std::string& symbol_name,
+                           Symbol lhs,
+                           Symbol rhs) {
+  return Operator("elemwise_add")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_power(const std::string& symbol_name,
+                              Symbol lhs,
+                              Symbol rhs) {
+  return Operator("broadcast_power")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_maximum(const std::string& symbol_name,
+                                Symbol lhs,
+                                Symbol rhs) {
+  return Operator("broadcast_maximum")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_minimum(const std::string& symbol_name,
+                                Symbol lhs,
+                                Symbol rhs) {
+  return Operator("broadcast_minimum")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_hypot(const std::string& symbol_name,
+                              Symbol lhs,
+                              Symbol rhs) {
+  return Operator("broadcast_hypot")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
  * \breif Compute argmax
  *
  *        From:src/operator/tensor/broadcast_reduce_op_index.cc:11
@@ -249,279 +639,6 @@ inline Symbol norm(const std::string& symbol_name,
                    Symbol src) {
   return Operator("norm")
            .SetInput("src", src)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif
- * \param symbol_name name of the resulting symbol
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_add(const std::string& symbol_name,
-                            Symbol lhs,
-                            Symbol rhs) {
-  return Operator("broadcast_add")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif
- * \param symbol_name name of the resulting symbol
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_sub(const std::string& symbol_name,
-                            Symbol lhs,
-                            Symbol rhs) {
-  return Operator("broadcast_sub")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif
- * \param symbol_name name of the resulting symbol
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_mul(const std::string& symbol_name,
-                            Symbol lhs,
-                            Symbol rhs) {
-  return Operator("broadcast_mul")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif
- * \param symbol_name name of the resulting symbol
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_div(const std::string& symbol_name,
-                            Symbol lhs,
-                            Symbol rhs) {
-  return Operator("broadcast_div")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif
- * \param symbol_name name of the resulting symbol
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_power(const std::string& symbol_name,
-                              Symbol lhs,
-                              Symbol rhs) {
-  return Operator("broadcast_power")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif
- * \param symbol_name name of the resulting symbol
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_maximum(const std::string& symbol_name,
-                                Symbol lhs,
-                                Symbol rhs) {
-  return Operator("broadcast_maximum")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif
- * \param symbol_name name of the resulting symbol
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_minimum(const std::string& symbol_name,
-                                Symbol lhs,
-                                Symbol rhs) {
-  return Operator("broadcast_minimum")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif
- * \param symbol_name name of the resulting symbol
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_hypot(const std::string& symbol_name,
-                              Symbol lhs,
-                              Symbol rhs) {
-  return Operator("broadcast_hypot")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif
- * \param symbol_name name of the resulting symbol
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_equal(const std::string& symbol_name,
-                              Symbol lhs,
-                              Symbol rhs) {
-  return Operator("broadcast_equal")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif
- * \param symbol_name name of the resulting symbol
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_not_equal(const std::string& symbol_name,
-                                  Symbol lhs,
-                                  Symbol rhs) {
-  return Operator("broadcast_not_equal")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif
- * \param symbol_name name of the resulting symbol
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_greater(const std::string& symbol_name,
-                                Symbol lhs,
-                                Symbol rhs) {
-  return Operator("broadcast_greater")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif
- * \param symbol_name name of the resulting symbol
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_greater_equal(const std::string& symbol_name,
-                                      Symbol lhs,
-                                      Symbol rhs) {
-  return Operator("broadcast_greater_equal")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif
- * \param symbol_name name of the resulting symbol
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_lesser(const std::string& symbol_name,
-                               Symbol lhs,
-                               Symbol rhs) {
-  return Operator("broadcast_lesser")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif
- * \param symbol_name name of the resulting symbol
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_lesser_equal(const std::string& symbol_name,
-                                     Symbol lhs,
-                                     Symbol rhs) {
-  return Operator("broadcast_lesser_equal")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif
- * \param symbol_name name of the resulting symbol
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol elemwise_add(const std::string& symbol_name,
-                           Symbol lhs,
-                           Symbol rhs) {
-  return Operator("elemwise_add")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Calculate Smooth L1 Loss(lhs, scalar)
- *
- *        From:src/operator/tensor/elemwise_binary_scalar_op_extended.cc:63
- * \param symbol_name name of the resulting symbol
- * \param data source input
- * \param scalar scalar input
- * \return new symbol
- */
-inline Symbol smooth_l1(const std::string& symbol_name,
-                        Symbol data,
-                        mx_float scalar) {
-  return Operator("smooth_l1")
-           .SetParam("scalar", scalar)
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Perform element sum of inputs
- *
- *        From:src/operator/tensor/elemwise_sum.cc:56
- * \param symbol_name name of the resulting symbol
- * \param args List of input tensors
- * \return new symbol
- */
-inline Symbol ElementWiseSum(const std::string& symbol_name,
-                             const std::vector<Symbol>& args) {
-  return Operator("ElementWiseSum")
-(args)
            .CreateSymbol(symbol_name);
 }
 
@@ -1021,6 +1138,24 @@ inline Symbol gammaln(const std::string& symbol_name,
 }
 
 /*!
+ * \breif Calculate Smooth L1 Loss(lhs, scalar)
+ *
+ *        From:src/operator/tensor/elemwise_binary_scalar_op_extended.cc:63
+ * \param symbol_name name of the resulting symbol
+ * \param data source input
+ * \param scalar scalar input
+ * \return new symbol
+ */
+inline Symbol smooth_l1(const std::string& symbol_name,
+                        Symbol data,
+                        mx_float scalar) {
+  return Operator("smooth_l1")
+           .SetParam("scalar", scalar)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
  * \breif Map integer index to vector representations (embeddings). Those
  *        embeddings are learnable parameters. For a input of shape (d1, ...,
  *        dK), the output shape is (d1, ..., dK, output_dim). All the input
@@ -1047,246 +1182,96 @@ inline Symbol Embedding(const std::string& symbol_name,
 }
 
 /*!
- * \breif Reshape input according to a target shape spec.
- *        The target shape is a tuple and can be a simple list of dimensions
- *        such as (12,3) or it can incorporate special codes that correspond
- *        The special codes are all expressed as integers less than 1. These
- *        codes effectively refer to a machine that pops input dims off the
- *        beginning of the input dims list and pushes resulting output dims
- *        onto the end of the output dims list, which starts empty. The codes
- *        0  Copy     Pop one input dim and push it onto the output dims
- *        -1  Infer    Push a dim that is inferred later from all other output
- *        -2  CopyAll  Pop all remaining input dims and push them onto output
- *        -3  Merge2   Pop two input dims, multiply them, and push result
- *        -4  Split2   Pop one input dim, and read two next target shape specs,
- *        push them both onto output dims (either can be -1 and will
- *        be inferred from the other
- *        The exact mathematical behavior of these codes is given in the
- *        description of the 'shape' parameter. All non-codes (positive
- *        integers) just pop a dim off the input dims (if any), throw it away,
- *        Examples:
- *        Type     Input      Target            Output
- *        Copy     (2,3,4)    (4,0,2)           (4,3,2)
- *        Copy     (2,3,4)    (2,0,0)           (2,3,4)
- *        Infer    (2,3,4)    (6,1,-1)          (6,1,4)
- *        Infer    (2,3,4)    (3,-1,8)          (3,1,8)
- *        CopyAll  (9,8,7)    (-2)              (9,8,7)
- *        CopyAll  (9,8,7)    (9,-2)            (9,8,7)
- *        CopyAll  (9,8,7)    (-2,1,1)          (9,8,7,1,1)
- *        Merge2   (3,4)      (-3)              (12)
- *        Merge2   (3,4,5)    (-3,0)            (12,5)
- *        Merge2   (3,4,5)    (0,-3)            (3,20)
- *        Merge2   (3,4,5,6)  (-3,0,0)          (12,5,6)
- *        Merge2   (3,4,5,6)  (-3,-2)           (12,5,6)
- *        Split2   (12)       (-4,6,2)          (6,2)
- *        Split2   (12)       (-4,2,6)          (2,6)
- *        Split2   (12)       (-4,-1,6)         (2,6)
- *        Split2   (12,9)     (-4,2,6,0)        (2,6,9)
- *        Split2   (12,9,9,9) (-4,2,6,-2)       (2,6,9,9,9)
- *        Split2   (12,12)    (-4,2,-1,-4,-1,2) (2,6,6,2)
- *
- *
- *        From:src/operator/tensor/matrix_op.cc:61
+ * \breif
  * \param symbol_name name of the resulting symbol
- * \param data Input data to reshape.
- * \param target_shape (Deprecated! Use shape instead.) Target new shape. One
- *        and only one dim can be 0, in which case it will be inferred from
- * \param keep_highest (Deprecated! Use shape instead.) Whether keep the
- *        highest dim unchanged.If set to true, then the first dim in
- * \param shape Target shape, a tuple, t=(t_1,t_2,..,t_m).
- *        Let the input dims be s=(s_1,s_2,..,s_n).
- *        The output dims u=(u_1,u_2,..,u_p) are computed from s and t.
- *        The target shape tuple elements t_i are read in order, and used to
- *        t_i:       meaning:      behavior:
- *        +ve        explicit      u_p = t_i
- *        0          copy          u_p = s_i
- *        -1         infer         u_p = (Prod s_i) / (Prod u_j | j != p)
- *        -2         copy all      u_p = s_i, u_p+1 = s_i+1, ...
- *        -3         merge two     u_p = s_i * s_i+1
- *        -4,a,b     split two     u_p = a, u_p+1 = b | a * b = s_i
- *        The split directive (-4) in the target shape tuple is followed by two
- *        dimensions, one of which can be -1, which means it will be inferred
- *        The can only be one globally inferred dimension (-1), aside from any
- * \param reverse Whether to match the shapes from the backward. If reverse is
- *        true, 0 values in the `shape` argument will be searched from the
- *        backward. E.g the original shape is (10, 5, 4) and the shape
- *        argument is (-1, 0). If reverse is true, the new shape should be
+ * \param lhs first input
+ * \param rhs second input
  * \return new symbol
  */
-inline Symbol Reshape(const std::string& symbol_name,
-                      Symbol data,
-                      Shape target_shape = Shape(0,0),
-                      bool keep_highest = false,
-                      Shape shape = Shape(),
-                      bool reverse = false) {
-  return Operator("Reshape")
-           .SetParam("target_shape", target_shape)
-           .SetParam("keep_highest", keep_highest)
-           .SetParam("shape", shape)
-           .SetParam("reverse", reverse)
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Flatten input into 2D by collapsing all the higher dimensions.
- *        A (d1, d2, ..., dK) tensor is flatten to (d1, d2* ... *dK) matrix.
- * \param symbol_name name of the resulting symbol
- * \param data Input data to reshape.
- * \return new symbol
- */
-inline Symbol Flatten(const std::string& symbol_name,
-                      Symbol data) {
-  return Operator("Flatten")
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Transpose the input tensor and return a new one
- *
- *        From:src/operator/tensor/matrix_op.cc:93
- * \param symbol_name name of the resulting symbol
- * \param data Source input
- * \param axes Target axis order. By default the axes will be inverted.
- * \return new symbol
- */
-inline Symbol transpose(const std::string& symbol_name,
-                        Symbol data,
-                        Shape axes = Shape()) {
-  return Operator("transpose")
-           .SetParam("axes", axes)
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Expand the shape of array by inserting a new axis.
- *
- *        From:src/operator/tensor/matrix_op.cc:121
- * \param symbol_name name of the resulting symbol
- * \param data Source input
- * \param axis Position (amongst axes) where new axis is to be inserted.
- * \return new symbol
- */
-inline Symbol expand_dims(const std::string& symbol_name,
-                          Symbol data,
-                          int axis) {
-  return Operator("expand_dims")
-           .SetParam("axis", axis)
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif (Crop the input tensor and return a new one.
- *
- *        Requirements
- *        ------------
- *        - the input and output (if explicitly given) are of the same data
- *        and on the same device.
- *        )
- *
- *        From:src/operator/tensor/matrix_op.cc:142
- * \param symbol_name name of the resulting symbol
- * \param data Source input
- * \param begin starting coordinates
- * \param end ending coordinates
- * \return new symbol
- */
-inline Symbol crop(const std::string& symbol_name,
-                   Symbol data,
-                   Shape begin,
-                   Shape end) {
-  return Operator("crop")
-           .SetParam("begin", begin)
-           .SetParam("end", end)
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Slice the input along certain axis and return a sliced array.
- *
- *        From:src/operator/tensor/matrix_op.cc:197
- * \param symbol_name name of the resulting symbol
- * \param data Source input
- * \param axis The axis to be sliced
- * \param begin The beginning index to be sliced
- * \param end The end index to be sliced
- * \return new symbol
- */
-inline Symbol slice_axis(const std::string& symbol_name,
-                         Symbol data,
-                         int axis,
-                         int begin,
-                         int end) {
-  return Operator("slice_axis")
-           .SetParam("axis", axis)
-           .SetParam("begin", begin)
-           .SetParam("end", end)
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Flip the input tensor along axis and return a new one.
- *
- *        From:src/operator/tensor/matrix_op.cc:216
- * \param symbol_name name of the resulting symbol
- * \param data Source input
- * \param axis The dimension to flip
- * \return new symbol
- */
-inline Symbol flip(const std::string& symbol_name,
-                   Symbol data,
-                   int axis) {
-  return Operator("flip")
-           .SetParam("axis", axis)
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Calculate dot product of two matrices or two vectors.
- *
- *        From:src/operator/tensor/matrix_op.cc:228
- * \param symbol_name name of the resulting symbol
- * \param lhs Left input
- * \param rhs Right input
- * \param transpose_a True if the first matrix is transposed.
- * \param transpose_b True if the second matrix is tranposed.
- * \return new symbol
- */
-inline Symbol dot(const std::string& symbol_name,
-                  Symbol lhs,
-                  Symbol rhs,
-                  bool transpose_a = false,
-                  bool transpose_b = false) {
-  return Operator("dot")
-           .SetParam("transpose_a", transpose_a)
-           .SetParam("transpose_b", transpose_b)
+inline Symbol broadcast_equal(const std::string& symbol_name,
+                              Symbol lhs,
+                              Symbol rhs) {
+  return Operator("broadcast_equal")
            .SetInput("lhs", lhs)
            .SetInput("rhs", rhs)
            .CreateSymbol(symbol_name);
 }
 
 /*!
- * \breif Calculate batched dot product of two matrices. (batch, M, K)
- *
- *        From:src/operator/tensor/matrix_op.cc:254
+ * \breif
  * \param symbol_name name of the resulting symbol
- * \param lhs Left input
- * \param rhs Right input
- * \param axis The dimension to flip
+ * \param lhs first input
+ * \param rhs second input
  * \return new symbol
  */
-inline Symbol batch_dot(const std::string& symbol_name,
-                        Symbol lhs,
-                        Symbol rhs,
-                        int axis) {
-  return Operator("batch_dot")
-           .SetParam("axis", axis)
+inline Symbol broadcast_not_equal(const std::string& symbol_name,
+                                  Symbol lhs,
+                                  Symbol rhs) {
+  return Operator("broadcast_not_equal")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_greater(const std::string& symbol_name,
+                                Symbol lhs,
+                                Symbol rhs) {
+  return Operator("broadcast_greater")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_greater_equal(const std::string& symbol_name,
+                                      Symbol lhs,
+                                      Symbol rhs) {
+  return Operator("broadcast_greater_equal")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_lesser(const std::string& symbol_name,
+                               Symbol lhs,
+                               Symbol rhs) {
+  return Operator("broadcast_lesser")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_lesser_equal(const std::string& symbol_name,
+                                     Symbol lhs,
+                                     Symbol rhs) {
+  return Operator("broadcast_lesser_equal")
            .SetInput("lhs", lhs)
            .SetInput("rhs", rhs)
            .CreateSymbol(symbol_name);
@@ -1335,20 +1320,17 @@ inline Symbol normal(const std::string& symbol_name,
 }
 
 /*!
- * \breif Calculate cross_entropy(lhs, one_hot(rhs))
+ * \breif Perform element sum of inputs
  *
- *        From:src/operator/loss_binary_op.cc:12
+ *        From:src/operator/tensor/elemwise_sum.cc:56
  * \param symbol_name name of the resulting symbol
- * \param data Input data
- * \param label Input label
+ * \param args List of input tensors
  * \return new symbol
  */
-inline Symbol softmax_cross_entropy(const std::string& symbol_name,
-                                    Symbol data,
-                                    Symbol label) {
-  return Operator("softmax_cross_entropy")
-           .SetInput("data", data)
-           .SetInput("label", label)
+inline Symbol ElementWiseSum(const std::string& symbol_name,
+                             const std::vector<Symbol>& args) {
+  return Operator("ElementWiseSum")
+(args)
            .CreateSymbol(symbol_name);
 }
 
@@ -1382,429 +1364,21 @@ inline Symbol adam_update(const std::string& symbol_name) {
            .CreateSymbol(symbol_name);
 }
 
-/*! \breif Activation function to be applied.
- */
-enum class ActivationActType {
-  relu = 0,
-  sigmoid = 1,
-  softrelu = 2,
-  tanh = 3
-};
-
 /*!
- * \breif Elementwise activation function.
+ * \breif Calculate cross_entropy(lhs, one_hot(rhs))
  *
- *        The following activation types are supported (operations are applied
- *        scalar of the input tensor):
- *
- *        - `relu`: Rectified Linear Unit, `y = max(x, 0)`
- *        - `sigmoid`: `y = 1 / (1 + exp(-x))`
- *        - `tanh`: Hyperbolic tangent, `y = (exp(x) - exp(-x)) / (exp(x) +
- *        - `softrelu`: Soft ReLU, or SoftPlus, `y = log(1 + exp(x))`
- *
- *        See `LeakyReLU` for other activations with parameters.
- *
+ *        From:src/operator/loss_binary_op.cc:12
  * \param symbol_name name of the resulting symbol
- * \param data Input data to activation function.
- * \param act_type Activation function to be applied.
+ * \param data Input data
+ * \param label Input label
  * \return new symbol
  */
-inline Symbol Activation(const std::string& symbol_name,
-                         Symbol data,
-                         ActivationActType act_type) {
-  static const char *ActivationActTypeValues[] = {
-    "relu",
-    "sigmoid",
-    "softrelu",
-    "tanh"
-  };
-  return Operator("Activation")
-           .SetParam("act_type", ActivationActTypeValues[int(act_type)])
+inline Symbol softmax_cross_entropy(const std::string& symbol_name,
+                                    Symbol data,
+                                    Symbol label) {
+  return Operator("softmax_cross_entropy")
            .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Apply batch normalization to input.
- * \param symbol_name name of the resulting symbol
- * \param data Input data to batch normalization
- * \param eps Epsilon to prevent div 0
- * \param momentum Momentum for moving average
- * \param fix_gamma Fix gamma while training
- * \param use_global_stats Whether use global moving statistics instead of
- *        local batch-norm. This will force change batch-norm into a scale
- * \return new symbol
- */
-inline Symbol BatchNorm(const std::string& symbol_name,
-                        Symbol data,
-                        mx_float eps = 0.001,
-                        mx_float momentum = 0.9,
-                        bool fix_gamma = true,
-                        bool use_global_stats = false) {
-  return Operator("BatchNorm")
-           .SetParam("eps", eps)
-           .SetParam("momentum", momentum)
-           .SetParam("fix_gamma", fix_gamma)
-           .SetParam("use_global_stats", use_global_stats)
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Get output from a symbol and pass 0 gradient back
- * \param symbol_name name of the resulting symbol
- * \param data Input data.
- * \return new symbol
- */
-inline Symbol BlockGrad(const std::string& symbol_name,
-                        Symbol data) {
-  return Operator("BlockGrad")
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*! \breif Target data type.
- */
-enum class CastDtype {
-  float16 = 0,
-  float32 = 1,
-  float64 = 2,
-  int32 = 3,
-  uint8 = 4
-};
-
-/*!
- * \breif Cast array to a different data type.
- * \param symbol_name name of the resulting symbol
- * \param data Input data to cast function.
- * \param dtype Target data type.
- * \return new symbol
- */
-inline Symbol Cast(const std::string& symbol_name,
-                   Symbol data,
-                   CastDtype dtype) {
-  static const char *CastDtypeValues[] = {
-    "float16",
-    "float32",
-    "float64",
-    "int32",
-    "uint8"
-  };
-  return Operator("Cast")
-           .SetParam("dtype", CastDtypeValues[int(dtype)])
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Perform a feature concat on channel dim (defaut is 1) over all
- * \param symbol_name name of the resulting symbol
- * \param data List of tensors to concatenate
- * \param num_args Number of inputs to be concated.
- * \param dim the dimension to be concated.
- * \return new symbol
- */
-inline Symbol Concat(const std::string& symbol_name,
-                     const std::vector<Symbol>& data,
-                     int num_args,
-                     int dim = 1) {
-  return Operator("Concat")
-           .SetParam("num_args", num_args)
-           .SetParam("dim", dim)
-(data)
-           .CreateSymbol(symbol_name);
-}
-
-/*! \breif Whether to pick convolution algo by running performance test.
- *        Leads to higher startup time but may give faster speed. Options are:
- *        'off': no tuning
- *        'limited_workspace': run test and pick the fastest algorithm that
- *        'fastest': pick the fastest algorithm and ignore workspace limit.
- *        If set to None (default), behavior is determined by environment
- *        variable MXNET_CUDNN_AUTOTUNE_DEFAULT: 0 for off,
- *        1 for limited workspace (default), 2 for fastest.
- */
-enum class ConvolutionCudnnTune {
-  None = 0,
-  fastest = 1,
-  limited_workspace = 2,
-  off = 3
-};
-
-/*! \breif Set layout for input, output and weight. Empty for
- *        default layout: NCHW for 2d and NCDHW for 3d.
- */
-enum class ConvolutionLayout {
-  None = 0,
-  NCDHW = 1,
-  NCHW = 2,
-  NDHWC = 3,
-  NHWC = 4
-};
-
-/*!
- * \breif Apply convolution to input then add a bias.
- * \param symbol_name name of the resulting symbol
- * \param data Input data to the ConvolutionOp.
- * \param weight Weight matrix.
- * \param bias Bias parameter.
- * \param kernel convolution kernel size: (h, w) or (d, h, w)
- * \param num_filter convolution filter(channel) number
- * \param stride convolution stride: (h, w) or (d, h, w)
- * \param dilate convolution dilate: (h, w) or (d, h, w)
- * \param pad pad for convolution: (h, w) or (d, h, w)
- * \param num_group Number of group partitions. Equivalent to slicing input
- *        partitions, apply convolution on each, then concatenate the results
- * \param workspace Maximum tmp workspace allowed for convolution (MB).
- * \param no_bias Whether to disable bias parameter.
- * \param cudnn_tune Whether to pick convolution algo by running performance
- *        Leads to higher startup time but may give faster speed. Options are:
- *        'off': no tuning
- *        'limited_workspace': run test and pick the fastest algorithm that
- *        'fastest': pick the fastest algorithm and ignore workspace limit.
- *        If set to None (default), behavior is determined by environment
- *        variable MXNET_CUDNN_AUTOTUNE_DEFAULT: 0 for off,
- *        1 for limited workspace (default), 2 for fastest.
- * \param cudnn_off Turn off cudnn for this layer.
- * \param layout Set layout for input, output and weight. Empty for
- *        default layout: NCHW for 2d and NCDHW for 3d.
- * \return new symbol
- */
-inline Symbol Convolution(const std::string& symbol_name,
-                          Symbol data,
-                          Symbol weight,
-                          Symbol bias,
-                          Shape kernel,
-                          int num_filter,
-                          Shape stride = Shape(),
-                          Shape dilate = Shape(),
-                          Shape pad = Shape(),
-                          int num_group = 1,
-                          int64_t workspace = 1024,
-                          bool no_bias = false,
-                          ConvolutionCudnnTune cudnn_tune = ConvolutionCudnnTune::None,
-                          bool cudnn_off = false,
-                          ConvolutionLayout layout = ConvolutionLayout::None) {
-  static const char *ConvolutionCudnnTuneValues[] = {
-    "None",
-    "fastest",
-    "limited_workspace",
-    "off"
-  };
-  static const char *ConvolutionLayoutValues[] = {
-    "None",
-    "NCDHW",
-    "NCHW",
-    "NDHWC",
-    "NHWC"
-  };
-  return Operator("Convolution")
-           .SetParam("kernel", kernel)
-           .SetParam("num_filter", num_filter)
-           .SetParam("stride", stride)
-           .SetParam("dilate", dilate)
-           .SetParam("pad", pad)
-           .SetParam("num_group", num_group)
-           .SetParam("workspace", workspace)
-           .SetParam("no_bias", no_bias)
-           .SetParam("cudnn_tune", ConvolutionCudnnTuneValues[int(cudnn_tune)])
-           .SetParam("cudnn_off", cudnn_off)
-           .SetParam("layout", ConvolutionLayoutValues[int(layout)])
-           .SetInput("data", data)
-           .SetInput("weight", weight)
-           .SetInput("bias", bias)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Apply correlation to inputs
- * \param symbol_name name of the resulting symbol
- * \param data1 Input data1 to the correlation.
- * \param data2 Input data2 to the correlation.
- * \param kernel_size kernel size for Correlation must be an odd number
- * \param max_displacement Max displacement of Correlation
- * \param stride1 stride1 quantize data1 globally
- * \param stride2 stride2 quantize data2 within the neighborhood centered
- * \param pad_size pad for Correlation
- * \param is_multiply operation type is either multiplication or subduction
- * \return new symbol
- */
-inline Symbol Correlation(const std::string& symbol_name,
-                          Symbol data1,
-                          Symbol data2,
-                          int kernel_size = 1,
-                          int max_displacement = 1,
-                          int stride1 = 1,
-                          int stride2 = 1,
-                          int pad_size = 0,
-                          bool is_multiply = true) {
-  return Operator("Correlation")
-           .SetParam("kernel_size", kernel_size)
-           .SetParam("max_displacement", max_displacement)
-           .SetParam("stride1", stride1)
-           .SetParam("stride2", stride2)
-           .SetParam("pad_size", pad_size)
-           .SetParam("is_multiply", is_multiply)
-           .SetInput("data1", data1)
-           .SetInput("data2", data2)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Crop the 2nd and 3rd dim of input data, with the corresponding size
- *        of h_w or with width and height of the second input symbol, i.e.,
- *        with one input, we need h_w to specify the crop height and width,
- * \param symbol_name name of the resulting symbol
- * \param data Tensor or List of Tensors, the second input will be used as
- * \param num_args Number of inputs for crop, if equals one, then we will use
- *        the h_wfor crop height and width, else if equals two, then we will
- *        use the heightand width of the second input symbol, we name
- * \param offset crop offset coordinate: (y, x)
- * \param h_w crop height and weight: (h, w)
- * \param center_crop If set to true, then it will use be the center_crop,or it
- * \return new symbol
- */
-inline Symbol Crop(const std::string& symbol_name,
-                   Symbol data,
-                   int num_args,
-                   Shape offset = Shape(0,0),
-                   Shape h_w = Shape(0,0),
-                   bool center_crop = false) {
-  return Operator("Crop")
-           .SetParam("num_args", num_args)
-           .SetParam("offset", offset)
-           .SetParam("h_w", h_w)
-           .SetParam("center_crop", center_crop)
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Custom operator implemented in frontend.
- * \param symbol_name name of the resulting symbol
- * \param op_type Type of custom operator. Must be registered first.
- * \return new symbol
- */
-inline Symbol Custom(const std::string& symbol_name,
-                     const std::string& op_type) {
-  return Operator("Custom")
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Apply deconvolution to input then add a bias.
- * \param symbol_name name of the resulting symbol
- * \param data Input data to the DeconvolutionOp.
- * \param weight Weight matrix.
- * \param bias Bias parameter.
- * \param kernel deconvolution kernel size: (y, x)
- * \param num_filter deconvolution filter(channel) number
- * \param stride deconvolution stride: (y, x)
- * \param pad pad for deconvolution: (y, x), a good number is : (kernel-1)/2,
- *        if target_shape set, pad will be ignored and will be computed
- * \param adj adjustment for output shape: (y, x), if target_shape set, adj
- * \param target_shape output shape with targe shape : (y, x)
- * \param num_group number of groups partition
- * \param workspace Tmp workspace for deconvolution (MB)
- * \param no_bias Whether to disable bias parameter.
- * \return new symbol
- */
-inline Symbol Deconvolution(const std::string& symbol_name,
-                            Symbol data,
-                            Symbol weight,
-                            Symbol bias,
-                            Shape kernel,
-                            int num_filter,
-                            Shape stride = Shape(1,1),
-                            Shape pad = Shape(0,0),
-                            Shape adj = Shape(0,0),
-                            Shape target_shape = Shape(0,0),
-                            int num_group = 1,
-                            int64_t workspace = 512,
-                            bool no_bias = true) {
-  return Operator("Deconvolution")
-           .SetParam("kernel", kernel)
-           .SetParam("num_filter", num_filter)
-           .SetParam("stride", stride)
-           .SetParam("pad", pad)
-           .SetParam("adj", adj)
-           .SetParam("target_shape", target_shape)
-           .SetParam("num_group", num_group)
-           .SetParam("workspace", workspace)
-           .SetParam("no_bias", no_bias)
-           .SetInput("data", data)
-           .SetInput("weight", weight)
-           .SetInput("bias", bias)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Apply dropout to input.
- *        During training, each element of the input is randomly set to zero
- *        And then the whole tensor is rescaled by 1/(1-p) to keep the
- *        before applying dropout. During the test time, this behaves as an
- *
- * \param symbol_name name of the resulting symbol
- * \param data Input data to dropout.
- * \param p Fraction of the input that gets dropped out at training time
- * \return new symbol
- */
-inline Symbol Dropout(const std::string& symbol_name,
-                      Symbol data,
-                      mx_float p = 0.5) {
-  return Operator("Dropout")
-           .SetParam("p", p)
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Apply matrix multiplication to input then add a bias.
- *        It maps the input of shape `(batch_size, input_dim)` to the shape of
- *        `(batch_size, num_hidden)`. Learnable parameters include the weights
- *        of the linear transform and an optional bias vector.
- * \param symbol_name name of the resulting symbol
- * \param data Input data to the FullyConnectedOp.
- * \param weight Weight matrix.
- * \param bias Bias parameter.
- * \param num_hidden Number of hidden nodes of the output.
- * \param no_bias Whether to disable bias parameter.
- * \return new symbol
- */
-inline Symbol FullyConnected(const std::string& symbol_name,
-                             Symbol data,
-                             Symbol weight,
-                             Symbol bias,
-                             int num_hidden,
-                             bool no_bias = false) {
-  return Operator("FullyConnected")
-           .SetParam("num_hidden", num_hidden)
-           .SetParam("no_bias", no_bias)
-           .SetInput("data", data)
-           .SetInput("weight", weight)
-           .SetInput("bias", bias)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Apply a sparse regularization to the output a sigmoid activation
- * \param symbol_name name of the resulting symbol
- * \param data Input data.
- * \param sparseness_target The sparseness target
- * \param penalty The tradeoff parameter for the sparseness penalty
- * \param momentum The momentum for running average
- * \return new symbol
- */
-inline Symbol IdentityAttachKLSparseReg(const std::string& symbol_name,
-                                        Symbol data,
-                                        mx_float sparseness_target = 0.1,
-                                        mx_float penalty = 0.001,
-                                        mx_float momentum = 0.9) {
-  return Operator("IdentityAttachKLSparseReg")
-           .SetParam("sparseness_target", sparseness_target)
-           .SetParam("penalty", penalty)
-           .SetParam("momentum", momentum)
-           .SetInput("data", data)
+           .SetInput("label", label)
            .CreateSymbol(symbol_name);
 }
 
@@ -1838,298 +1412,26 @@ inline Symbol InstanceNorm(const std::string& symbol_name,
            .CreateSymbol(symbol_name);
 }
 
-/*! \breif Normalization Mode. If set to instance, this operator will compute a
- *        norm for each instance in the batch; this is the default mode. If
- *        set to channel, this operator will compute a cross channel norm at
- *        each position of each instance. If set to spatial, this operator
- */
-enum class L2NormalizationMode {
-  channel = 0,
-  instance = 1,
-  spatial = 2
-};
-
 /*!
- * \breif Set the l2 norm of each instance to a constant.
+ * \breif Support Vector Machine based transformation on input, backprop L2-SVM
  * \param symbol_name name of the resulting symbol
- * \param data Input data to the L2NormalizationOp.
- * \param eps Epsilon to prevent div 0
- * \param mode Normalization Mode. If set to instance, this operator will
- *        compute a norm for each instance in the batch; this is the default
- *        mode. If set to channel, this operator will compute a cross channel
- *        norm at each position of each instance. If set to spatial, this
+ * \param data Input data to svm.
+ * \param label Label data.
+ * \param margin Scale the DType(param_.margin) for activation size
+ * \param regularization_coefficient Scale the coefficient responsible for
+ * \param use_linear If set true, uses L1-SVM objective function. Default uses
  * \return new symbol
  */
-inline Symbol L2Normalization(const std::string& symbol_name,
-                              Symbol data,
-                              mx_float eps = 1e-10,
-                              L2NormalizationMode mode = L2NormalizationMode::instance) {
-  static const char *L2NormalizationModeValues[] = {
-    "channel",
-    "instance",
-    "spatial"
-  };
-  return Operator("L2Normalization")
-           .SetParam("eps", eps)
-           .SetParam("mode", L2NormalizationModeValues[int(mode)])
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*! \breif Activation function to be applied.
- */
-enum class LeakyReLUActType {
-  elu = 0,
-  leaky = 1,
-  prelu = 2,
-  rrelu = 3
-};
-
-/*!
- * \breif Apply activation function to input.
- * \param symbol_name name of the resulting symbol
- * \param data Input data to activation function.
- * \param act_type Activation function to be applied.
- * \param slope Init slope for the activation. (For leaky and elu only)
- * \param lower_bound Lower bound of random slope. (For rrelu only)
- * \param upper_bound Upper bound of random slope. (For rrelu only)
- * \return new symbol
- */
-inline Symbol LeakyReLU(const std::string& symbol_name,
+inline Symbol SVMOutput(const std::string& symbol_name,
                         Symbol data,
-                        LeakyReLUActType act_type = LeakyReLUActType::leaky,
-                        mx_float slope = 0.25,
-                        mx_float lower_bound = 0.125,
-                        mx_float upper_bound = 0.334) {
-  static const char *LeakyReLUActTypeValues[] = {
-    "elu",
-    "leaky",
-    "prelu",
-    "rrelu"
-  };
-  return Operator("LeakyReLU")
-           .SetParam("act_type", LeakyReLUActTypeValues[int(act_type)])
-           .SetParam("slope", slope)
-           .SetParam("lower_bound", lower_bound)
-           .SetParam("upper_bound", upper_bound)
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Apply convolution to input then add a bias.
- * \param symbol_name name of the resulting symbol
- * \param data Input data to the ConvolutionOp.
- * \param nsize normalization window width in elements.
- * \param alpha value of the alpha variance scaling parameter in the
- * \param beta value of the beta power parameter in the normalization formula
- * \param knorm value of the k parameter in normalization formula
- * \return new symbol
- */
-inline Symbol LRN(const std::string& symbol_name,
-                  Symbol data,
-                  int nsize,
-                  mx_float alpha = 0.0001,
-                  mx_float beta = 0.75,
-                  mx_float knorm = 2) {
-  return Operator("LRN")
-           .SetParam("nsize", nsize)
-           .SetParam("alpha", alpha)
-           .SetParam("beta", beta)
-           .SetParam("knorm", knorm)
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*! \breif If set to null, op will not normalize on output gradient.If set to
- *        batch, op will normalize gradient by divide batch size.If set to
- */
-enum class MakeLossNormalization {
-  batch = 0,
-  null = 1,
-  valid = 2
-};
-
-/*!
- * \breif Get output from a symbol and pass 1 gradient back. This is used as a
- *        terminal loss if unary and binary operator are used to composite a
- * \param symbol_name name of the resulting symbol
- * \param data Input data.
- * \param grad_scale gradient scale as a supplement to unary and binary
- * \param valid_thresh regard element valid when x > valid_thresh, this is used
- * \param normalization If set to null, op will not normalize on output
- *        gradient.If set to batch, op will normalize gradient by divide batch
- *        size.If set to valid, op will normalize gradient by divide # sample
- * \return new symbol
- */
-inline Symbol MakeLoss(const std::string& symbol_name,
-                       Symbol data,
-                       mx_float grad_scale = 1,
-                       mx_float valid_thresh = 0,
-                       MakeLossNormalization normalization = MakeLossNormalization::null) {
-  static const char *MakeLossNormalizationValues[] = {
-    "batch",
-    "null",
-    "valid"
-  };
-  return Operator("MakeLoss")
-           .SetParam("grad_scale", grad_scale)
-           .SetParam("valid_thresh", valid_thresh)
-           .SetParam("normalization", MakeLossNormalizationValues[int(normalization)])
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*! \breif Padding type to use. "constant" pads all values with a constant
- *        value, the value of which can be specified with the constant_value
- */
-enum class PadMode {
-  constant = 0,
-  edge = 1
-};
-
-/*!
- * \breif Pads an n-dimensional input tensor. Allows for precise control of the
- *        padding type and how much padding to apply on both sides of a given
- * \param symbol_name name of the resulting symbol
- * \param data An n-dimensional input tensor.
- * \param mode Padding type to use. "constant" pads all values with a constant
- *        value, the value of which can be specified with the constant_value
- * \param pad_width A tuple of padding widths of length 2*r, where r is the
- *        rank of the input tensor, specifying number of values padded to the
- *        edges of each axis. (before_1, after_1, ... , before_N, after_N)
- *        unique pad widths for each axis. Equivalent to pad_width in
- * \param constant_value This option is only used when mode is "constant". This
- *        value will be used as the padding value. Defaults to 0 if not
- * \return new symbol
- */
-inline Symbol Pad(const std::string& symbol_name,
-                  Symbol data,
-                  PadMode mode,
-                  Shape pad_width,
-                  double constant_value = 0) {
-  static const char *PadModeValues[] = {
-    "constant",
-    "edge"
-  };
-  return Operator("Pad")
-           .SetParam("mode", PadModeValues[int(mode)])
-           .SetParam("pad_width", pad_width)
-           .SetParam("constant_value", constant_value)
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*! \breif Pooling type to be applied.
- */
-enum class PoolingPoolType {
-  avg = 0,
-  max = 1,
-  sum = 2
-};
-
-/*! \breif Pooling convention to be applied.kValid is default setting of Mxnet
- *        and rounds down the output pooling size.kFull is compatible with
- */
-enum class PoolingPoolingConvention {
-  full = 0,
-  valid = 1
-};
-
-/*!
- * \breif Perform spatial pooling on inputs.
- * \param symbol_name name of the resulting symbol
- * \param data Input data to the pooling operator.
- * \param kernel pooling kernel size: (y, x) or (d, y, x)
- * \param pool_type Pooling type to be applied.
- * \param global_pool Ignore kernel size, do global pooling based on current
- * \param pooling_convention Pooling convention to be applied.kValid is default
- *        setting of Mxnet and rounds down the output pooling size.kFull is
- * \param stride stride: for pooling (y, x) or (d, y, x)
- * \param pad pad for pooling: (y, x) or (d, y, x)
- * \return new symbol
- */
-inline Symbol Pooling(const std::string& symbol_name,
-                      Symbol data,
-                      Shape kernel,
-                      PoolingPoolType pool_type,
-                      bool global_pool = false,
-                      PoolingPoolingConvention pooling_convention = PoolingPoolingConvention::valid,
-                      Shape stride = Shape(1,1),
-                      Shape pad = Shape(0,0)) {
-  static const char *PoolingPoolTypeValues[] = {
-    "avg",
-    "max",
-    "sum"
-  };
-  static const char *PoolingPoolingConventionValues[] = {
-    "full",
-    "valid"
-  };
-  return Operator("Pooling")
-           .SetParam("kernel", kernel)
-           .SetParam("pool_type", PoolingPoolTypeValues[int(pool_type)])
-           .SetParam("global_pool", global_pool)
-           .SetParam("pooling_convention", PoolingPoolingConventionValues[int(pooling_convention)])
-           .SetParam("stride", stride)
-           .SetParam("pad", pad)
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Use linear regression for final output, this is used on final output
- * \param symbol_name name of the resulting symbol
- * \param data Input data to function.
- * \param label Input label to function.
- * \param grad_scale Scale the gradient by a float factor
- * \return new symbol
- */
-inline Symbol LinearRegressionOutput(const std::string& symbol_name,
-                                     Symbol data,
-                                     Symbol label,
-                                     mx_float grad_scale = 1) {
-  return Operator("LinearRegressionOutput")
-           .SetParam("grad_scale", grad_scale)
-           .SetInput("data", data)
-           .SetInput("label", label)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Use mean absolute error regression for final output, this is used on
- * \param symbol_name name of the resulting symbol
- * \param data Input data to function.
- * \param label Input label to function.
- * \param grad_scale Scale the gradient by a float factor
- * \return new symbol
- */
-inline Symbol MAERegressionOutput(const std::string& symbol_name,
-                                  Symbol data,
-                                  Symbol label,
-                                  mx_float grad_scale = 1) {
-  return Operator("MAERegressionOutput")
-           .SetParam("grad_scale", grad_scale)
-           .SetInput("data", data)
-           .SetInput("label", label)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Use Logistic regression for final output, this is used on final
- *        Logistic regression is suitable for binary classification or
- * \param symbol_name name of the resulting symbol
- * \param data Input data to function.
- * \param label Input label to function.
- * \param grad_scale Scale the gradient by a float factor
- * \return new symbol
- */
-inline Symbol LogisticRegressionOutput(const std::string& symbol_name,
-                                       Symbol data,
-                                       Symbol label,
-                                       mx_float grad_scale = 1) {
-  return Operator("LogisticRegressionOutput")
-           .SetParam("grad_scale", grad_scale)
+                        Symbol label,
+                        mx_float margin = 1,
+                        mx_float regularization_coefficient = 1,
+                        bool use_linear = false) {
+  return Operator("SVMOutput")
+           .SetParam("margin", margin)
+           .SetParam("regularization_coefficient", regularization_coefficient)
+           .SetParam("use_linear", use_linear)
            .SetInput("data", data)
            .SetInput("label", label)
            .CreateSymbol(symbol_name);
@@ -2190,85 +1492,65 @@ inline Symbol RNN(const std::string& symbol_name,
            .CreateSymbol(symbol_name);
 }
 
+/*! \breif Target data type.
+ */
+enum class CastDtype {
+  float16 = 0,
+  float32 = 1,
+  float64 = 2,
+  int32 = 3,
+  uint8 = 4
+};
+
 /*!
- * \breif Performs region-of-interest pooling on inputs. Resize bounding box
- *        coordinates by spatial_scale and crop input feature maps
- *        accordingly. The cropped feature maps are pooled by max pooling to a
- *        fixed size output indicated by pooled_size. batch_size will change
+ * \breif Cast array to a different data type.
  * \param symbol_name name of the resulting symbol
- * \param data Input data to the pooling operator, a 4D Feature maps
- * \param rois Bounding box coordinates, a 2D array of [[batch_index, x1, y1,
- *        x2, y2]]. (x1, y1) and (x2, y2) are top left and down right corners
- *        of designated region of interest. batch_index indicates the index of
- * \param pooled_size fix pooled size: (h, w)
- * \param spatial_scale Ratio of input feature map height (or w) to raw image
- *        height (or w). Equals the reciprocal of total stride in
+ * \param data Input data to cast function.
+ * \param dtype Target data type.
  * \return new symbol
  */
-inline Symbol ROIPooling(const std::string& symbol_name,
-                         Symbol data,
-                         Symbol rois,
-                         Shape pooled_size,
-                         mx_float spatial_scale) {
-  return Operator("ROIPooling")
-           .SetParam("pooled_size", pooled_size)
-           .SetParam("spatial_scale", spatial_scale)
+inline Symbol Cast(const std::string& symbol_name,
+                   Symbol data,
+                   CastDtype dtype) {
+  static const char *CastDtypeValues[] = {
+    "float16",
+    "float32",
+    "float64",
+    "int32",
+    "uint8"
+  };
+  return Operator("Cast")
+           .SetParam("dtype", CastDtypeValues[int(dtype)])
            .SetInput("data", data)
-           .SetInput("rois", rois)
            .CreateSymbol(symbol_name);
 }
 
 /*!
- * \breif Takes the last element of a sequence. Takes an n-dimensional tensor
- *        of the form [max sequence length, batchsize, other dims] and returns
- *        a (n-1)-dimensional tensor of the form [batchsize, other dims]. This
- *        operator takes an optional input tensor sequence_length of positive
- *        ints of dimension [batchsize] when the sequence_length option is set
- *        to true. This allows the operator to handle variable-length
- *        sequences. If sequence_length is false, then each example in the
+ * \breif Crop the 2nd and 3rd dim of input data, with the corresponding size
+ *        of h_w or with width and height of the second input symbol, i.e.,
+ *        with one input, we need h_w to specify the crop height and width,
  * \param symbol_name name of the resulting symbol
- * \param data n-dimensional input tensor of the form [max sequence length,
- * \param sequence_length vector of sequence lengths of size batchsize
- * \param use_sequence_length If set to true, this layer takes in extra input
+ * \param data Tensor or List of Tensors, the second input will be used as
+ * \param num_args Number of inputs for crop, if equals one, then we will use
+ *        the h_wfor crop height and width, else if equals two, then we will
+ *        use the heightand width of the second input symbol, we name
+ * \param offset crop offset coordinate: (y, x)
+ * \param h_w crop height and weight: (h, w)
+ * \param center_crop If set to true, then it will use be the center_crop,or it
  * \return new symbol
  */
-inline Symbol SequenceLast(const std::string& symbol_name,
-                           Symbol data,
-                           Symbol sequence_length,
-                           bool use_sequence_length = false) {
-  return Operator("SequenceLast")
-           .SetParam("use_sequence_length", use_sequence_length)
+inline Symbol Crop(const std::string& symbol_name,
+                   Symbol data,
+                   int num_args,
+                   Shape offset = Shape(0,0),
+                   Shape h_w = Shape(0,0),
+                   bool center_crop = false) {
+  return Operator("Crop")
+           .SetParam("num_args", num_args)
+           .SetParam("offset", offset)
+           .SetParam("h_w", h_w)
+           .SetParam("center_crop", center_crop)
            .SetInput("data", data)
-           .SetInput("sequence_length", sequence_length)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Sets all elements outside the sequence to a constant value. Takes an
- *        n-dimensional tensor of the form [max sequence length, batchsize,
- *        other dims] and returns a tensor of the same shape. This operator
- *        takes an optional input tensor sequence_length of positive ints of
- *        dimension [batchsize] when the sequence_length option is set to
- *        true. This allows the operator to handle variable-length sequences.
- *        If sequence_length is false, then each example in the batch is
- *        assumed to have the max sequence length, and this operator becomes
- * \param symbol_name name of the resulting symbol
- * \param data n-dimensional input tensor of the form [max sequence length,
- * \param sequence_length vector of sequence lengths of size batchsize
- * \param use_sequence_length If set to true, this layer takes in extra input
- * \param value The value to be used as a mask.
- * \return new symbol
- */
-inline Symbol SequenceMask(const std::string& symbol_name,
-                           Symbol data,
-                           Symbol sequence_length,
-                           bool use_sequence_length = false,
-                           mx_float value = 0) {
-  return Operator("SequenceMask")
-           .SetParam("use_sequence_length", use_sequence_length)
-           .SetParam("value", value)
-           .SetInput("data", data)
-           .SetInput("sequence_length", sequence_length)
            .CreateSymbol(symbol_name);
 }
 
@@ -2297,59 +1579,106 @@ inline Symbol SequenceReverse(const std::string& symbol_name,
            .CreateSymbol(symbol_name);
 }
 
-/*!
- * \breif Slice input equally along specified axis
- * \param symbol_name name of the resulting symbol
- * \param num_outputs Number of outputs to be sliced.
- * \param axis Dimension along which to slice.
- * \param squeeze_axis If true AND the sliced dimension becomes 1, squeeze that
- * \return new symbol
+/*! \breif transformation type
  */
-inline Symbol SliceChannel(const std::string& symbol_name,
-                           int num_outputs,
-                           int axis = 1,
-                           bool squeeze_axis = false) {
-  return Operator("SliceChannel")
-           .SetParam("num_outputs", num_outputs)
-           .SetParam("axis", axis)
-           .SetParam("squeeze_axis", squeeze_axis)
-           .CreateSymbol(symbol_name);
-}
+enum class SpatialTransformerTransformType {
+  affine = 0
+};
 
-/*! \breif Softmax Mode. If set to instance, this operator will compute a
- *        softmax for each instance in the batch; this is the default mode. If
- *        set to channel, this operator will compute a num_channel-class
- *        softmax at each position of each instance; this can be used for
+/*! \breif sampling type
  */
-enum class SoftmaxActivationMode {
-  channel = 0,
-  instance = 1
+enum class SpatialTransformerSamplerType {
+  bilinear = 0
 };
 
 /*!
- * \breif Apply softmax activation to input. This is intended for internal
- *        layers. For output (loss layer) please use SoftmaxOutput. If
- *        mode=instance, this operator will compute a softmax for each
- *        instance in the batch; this is the default mode. If mode=channel,
- *        this operator will compute a num_channel-class softmax at each
- *        position of each instance; this can be used for fully convolutional
+ * \breif Apply spatial transformer to input feature map.
  * \param symbol_name name of the resulting symbol
- * \param data Input data to activation function.
- * \param mode Softmax Mode. If set to instance, this operator will compute a
- *        softmax for each instance in the batch; this is the default mode. If
- *        set to channel, this operator will compute a num_channel-class
- *        softmax at each position of each instance; this can be used for
+ * \param data Input data to the SpatialTransformerOp.
+ * \param loc localisation net, the output dim should be 6 when transform_type
+ *        is affine, and the name of loc symbol should better starts with
+ *        'stn_loc', so that initialization it with iddentify tranform, or you
+ * \param transform_type transformation type
+ * \param sampler_type sampling type
+ * \param target_shape output shape(h, w) of spatial transformer: (y, x)
  * \return new symbol
  */
-inline Symbol SoftmaxActivation(const std::string& symbol_name,
-                                Symbol data,
-                                SoftmaxActivationMode mode = SoftmaxActivationMode::instance) {
-  static const char *SoftmaxActivationModeValues[] = {
-    "channel",
-    "instance"
+inline Symbol SpatialTransformer(const std::string& symbol_name,
+                                 Symbol data,
+                                 Symbol loc,
+                                 SpatialTransformerTransformType transform_type,
+                                 SpatialTransformerSamplerType sampler_type,
+                                 Shape target_shape = Shape(0,0)) {
+  static const char *SpatialTransformerTransformTypeValues[] = {
+    "affine"
   };
-  return Operator("SoftmaxActivation")
-           .SetParam("mode", SoftmaxActivationModeValues[int(mode)])
+  static const char *SpatialTransformerSamplerTypeValues[] = {
+    "bilinear"
+  };
+  return Operator("SpatialTransformer")
+           .SetParam("transform_type", SpatialTransformerTransformTypeValues[int(transform_type)])
+           .SetParam("sampler_type", SpatialTransformerSamplerTypeValues[int(sampler_type)])
+           .SetParam("target_shape", target_shape)
+           .SetInput("data", data)
+           .SetInput("loc", loc)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Apply swapaxis to input.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the SwapAxisOp.
+ * \param dim1 the first axis to be swapped.
+ * \param dim2 the second axis to be swapped.
+ * \return new symbol
+ */
+inline Symbol SwapAxis(const std::string& symbol_name,
+                       Symbol data,
+                       int dim1 = 0,
+                       int dim2 = 0) {
+  return Operator("SwapAxis")
+           .SetParam("dim1", dim1)
+           .SetParam("dim2", dim2)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*! \breif Padding type to use. "constant" pads all values with a constant
+ *        value, the value of which can be specified with the constant_value
+ */
+enum class PadMode {
+  constant = 0,
+  edge = 1
+};
+
+/*!
+ * \breif Pads an n-dimensional input tensor. Allows for precise control of the
+ *        padding type and how much padding to apply on both sides of a given
+ * \param symbol_name name of the resulting symbol
+ * \param data An n-dimensional input tensor.
+ * \param mode Padding type to use. "constant" pads all values with a constant
+ *        value, the value of which can be specified with the constant_value
+ * \param pad_width A tuple of padding widths of length 2*r, where r is the
+ *        rank of the input tensor, specifying number of values padded to the
+ *        edges of each axis. (before_1, after_1, ... , before_N, after_N)
+ *        unique pad widths for each axis. Equivalent to pad_width in
+ * \param constant_value This option is only used when mode is "constant". This
+ *        value will be used as the padding value. Defaults to 0 if not
+ * \return new symbol
+ */
+inline Symbol Pad(const std::string& symbol_name,
+                  Symbol data,
+                  PadMode mode,
+                  Shape pad_width,
+                  double constant_value = 0) {
+  static const char *PadModeValues[] = {
+    "constant",
+    "edge"
+  };
+  return Operator("Pad")
+           .SetParam("mode", PadModeValues[int(mode)])
+           .SetParam("pad_width", pad_width)
+           .SetParam("constant_value", constant_value)
            .SetInput("data", data)
            .CreateSymbol(symbol_name);
 }
@@ -2461,91 +1790,228 @@ inline Symbol Softmax(const std::string& symbol_name,
            .CreateSymbol(symbol_name);
 }
 
-/*! \breif transformation type
+/*! \breif Activation function to be applied.
  */
-enum class SpatialTransformerTransformType {
-  affine = 0
-};
-
-/*! \breif sampling type
- */
-enum class SpatialTransformerSamplerType {
-  bilinear = 0
+enum class LeakyReLUActType {
+  elu = 0,
+  leaky = 1,
+  prelu = 2,
+  rrelu = 3
 };
 
 /*!
- * \breif Apply spatial transformer to input feature map.
+ * \breif Apply activation function to input.
  * \param symbol_name name of the resulting symbol
- * \param data Input data to the SpatialTransformerOp.
- * \param loc localisation net, the output dim should be 6 when transform_type
- *        is affine, and the name of loc symbol should better starts with
- *        'stn_loc', so that initialization it with iddentify tranform, or you
- * \param transform_type transformation type
- * \param sampler_type sampling type
- * \param target_shape output shape(h, w) of spatial transformer: (y, x)
+ * \param data Input data to activation function.
+ * \param act_type Activation function to be applied.
+ * \param slope Init slope for the activation. (For leaky and elu only)
+ * \param lower_bound Lower bound of random slope. (For rrelu only)
+ * \param upper_bound Upper bound of random slope. (For rrelu only)
  * \return new symbol
  */
-inline Symbol SpatialTransformer(const std::string& symbol_name,
-                                 Symbol data,
-                                 Symbol loc,
-                                 SpatialTransformerTransformType transform_type,
-                                 SpatialTransformerSamplerType sampler_type,
-                                 Shape target_shape = Shape(0,0)) {
-  static const char *SpatialTransformerTransformTypeValues[] = {
-    "affine"
-  };
-  static const char *SpatialTransformerSamplerTypeValues[] = {
-    "bilinear"
-  };
-  return Operator("SpatialTransformer")
-           .SetParam("transform_type", SpatialTransformerTransformTypeValues[int(transform_type)])
-           .SetParam("sampler_type", SpatialTransformerSamplerTypeValues[int(sampler_type)])
-           .SetParam("target_shape", target_shape)
-           .SetInput("data", data)
-           .SetInput("loc", loc)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Support Vector Machine based transformation on input, backprop L2-SVM
- * \param symbol_name name of the resulting symbol
- * \param data Input data to svm.
- * \param label Label data.
- * \param margin Scale the DType(param_.margin) for activation size
- * \param regularization_coefficient Scale the coefficient responsible for
- * \param use_linear If set true, uses L1-SVM objective function. Default uses
- * \return new symbol
- */
-inline Symbol SVMOutput(const std::string& symbol_name,
+inline Symbol LeakyReLU(const std::string& symbol_name,
                         Symbol data,
-                        Symbol label,
-                        mx_float margin = 1,
-                        mx_float regularization_coefficient = 1,
-                        bool use_linear = false) {
-  return Operator("SVMOutput")
-           .SetParam("margin", margin)
-           .SetParam("regularization_coefficient", regularization_coefficient)
-           .SetParam("use_linear", use_linear)
+                        LeakyReLUActType act_type = LeakyReLUActType::leaky,
+                        mx_float slope = 0.25,
+                        mx_float lower_bound = 0.125,
+                        mx_float upper_bound = 0.334) {
+  static const char *LeakyReLUActTypeValues[] = {
+    "elu",
+    "leaky",
+    "prelu",
+    "rrelu"
+  };
+  return Operator("LeakyReLU")
+           .SetParam("act_type", LeakyReLUActTypeValues[int(act_type)])
+           .SetParam("slope", slope)
+           .SetParam("lower_bound", lower_bound)
+           .SetParam("upper_bound", upper_bound)
            .SetInput("data", data)
-           .SetInput("label", label)
            .CreateSymbol(symbol_name);
 }
 
 /*!
- * \breif Apply swapaxis to input.
+ * \breif Takes the last element of a sequence. Takes an n-dimensional tensor
+ *        of the form [max sequence length, batchsize, other dims] and returns
+ *        a (n-1)-dimensional tensor of the form [batchsize, other dims]. This
+ *        operator takes an optional input tensor sequence_length of positive
+ *        ints of dimension [batchsize] when the sequence_length option is set
+ *        to true. This allows the operator to handle variable-length
+ *        sequences. If sequence_length is false, then each example in the
  * \param symbol_name name of the resulting symbol
- * \param data Input data to the SwapAxisOp.
- * \param dim1 the first axis to be swapped.
- * \param dim2 the second axis to be swapped.
+ * \param data n-dimensional input tensor of the form [max sequence length,
+ * \param sequence_length vector of sequence lengths of size batchsize
+ * \param use_sequence_length If set to true, this layer takes in extra input
  * \return new symbol
  */
-inline Symbol SwapAxis(const std::string& symbol_name,
-                       Symbol data,
-                       int dim1 = 0,
-                       int dim2 = 0) {
-  return Operator("SwapAxis")
-           .SetParam("dim1", dim1)
-           .SetParam("dim2", dim2)
+inline Symbol SequenceLast(const std::string& symbol_name,
+                           Symbol data,
+                           Symbol sequence_length,
+                           bool use_sequence_length = false) {
+  return Operator("SequenceLast")
+           .SetParam("use_sequence_length", use_sequence_length)
+           .SetInput("data", data)
+           .SetInput("sequence_length", sequence_length)
+           .CreateSymbol(symbol_name);
+}
+
+/*! \breif Normalization Mode. If set to instance, this operator will compute a
+ *        norm for each instance in the batch; this is the default mode. If
+ *        set to channel, this operator will compute a cross channel norm at
+ *        each position of each instance. If set to spatial, this operator
+ */
+enum class L2NormalizationMode {
+  channel = 0,
+  instance = 1,
+  spatial = 2
+};
+
+/*!
+ * \breif Set the l2 norm of each instance to a constant.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the L2NormalizationOp.
+ * \param eps Epsilon to prevent div 0
+ * \param mode Normalization Mode. If set to instance, this operator will
+ *        compute a norm for each instance in the batch; this is the default
+ *        mode. If set to channel, this operator will compute a cross channel
+ *        norm at each position of each instance. If set to spatial, this
+ * \return new symbol
+ */
+inline Symbol L2Normalization(const std::string& symbol_name,
+                              Symbol data,
+                              mx_float eps = 1e-10,
+                              L2NormalizationMode mode = L2NormalizationMode::instance) {
+  static const char *L2NormalizationModeValues[] = {
+    "channel",
+    "instance",
+    "spatial"
+  };
+  return Operator("L2Normalization")
+           .SetParam("eps", eps)
+           .SetParam("mode", L2NormalizationModeValues[int(mode)])
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Apply convolution to input then add a bias.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the ConvolutionOp.
+ * \param nsize normalization window width in elements.
+ * \param alpha value of the alpha variance scaling parameter in the
+ * \param beta value of the beta power parameter in the normalization formula
+ * \param knorm value of the k parameter in normalization formula
+ * \return new symbol
+ */
+inline Symbol LRN(const std::string& symbol_name,
+                  Symbol data,
+                  int nsize,
+                  mx_float alpha = 0.0001,
+                  mx_float beta = 0.75,
+                  mx_float knorm = 2) {
+  return Operator("LRN")
+           .SetParam("nsize", nsize)
+           .SetParam("alpha", alpha)
+           .SetParam("beta", beta)
+           .SetParam("knorm", knorm)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Apply correlation to inputs
+ * \param symbol_name name of the resulting symbol
+ * \param data1 Input data1 to the correlation.
+ * \param data2 Input data2 to the correlation.
+ * \param kernel_size kernel size for Correlation must be an odd number
+ * \param max_displacement Max displacement of Correlation
+ * \param stride1 stride1 quantize data1 globally
+ * \param stride2 stride2 quantize data2 within the neighborhood centered
+ * \param pad_size pad for Correlation
+ * \param is_multiply operation type is either multiplication or subduction
+ * \return new symbol
+ */
+inline Symbol Correlation(const std::string& symbol_name,
+                          Symbol data1,
+                          Symbol data2,
+                          int kernel_size = 1,
+                          int max_displacement = 1,
+                          int stride1 = 1,
+                          int stride2 = 1,
+                          int pad_size = 0,
+                          bool is_multiply = true) {
+  return Operator("Correlation")
+           .SetParam("kernel_size", kernel_size)
+           .SetParam("max_displacement", max_displacement)
+           .SetParam("stride1", stride1)
+           .SetParam("stride2", stride2)
+           .SetParam("pad_size", pad_size)
+           .SetParam("is_multiply", is_multiply)
+           .SetInput("data1", data1)
+           .SetInput("data2", data2)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Sets all elements outside the sequence to a constant value. Takes an
+ *        n-dimensional tensor of the form [max sequence length, batchsize,
+ *        other dims] and returns a tensor of the same shape. This operator
+ *        takes an optional input tensor sequence_length of positive ints of
+ *        dimension [batchsize] when the sequence_length option is set to
+ *        true. This allows the operator to handle variable-length sequences.
+ *        If sequence_length is false, then each example in the batch is
+ *        assumed to have the max sequence length, and this operator becomes
+ * \param symbol_name name of the resulting symbol
+ * \param data n-dimensional input tensor of the form [max sequence length,
+ * \param sequence_length vector of sequence lengths of size batchsize
+ * \param use_sequence_length If set to true, this layer takes in extra input
+ * \param value The value to be used as a mask.
+ * \return new symbol
+ */
+inline Symbol SequenceMask(const std::string& symbol_name,
+                           Symbol data,
+                           Symbol sequence_length,
+                           bool use_sequence_length = false,
+                           mx_float value = 0) {
+  return Operator("SequenceMask")
+           .SetParam("use_sequence_length", use_sequence_length)
+           .SetParam("value", value)
+           .SetInput("data", data)
+           .SetInput("sequence_length", sequence_length)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Get output from a symbol and pass 0 gradient back
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data.
+ * \return new symbol
+ */
+inline Symbol BlockGrad(const std::string& symbol_name,
+                        Symbol data) {
+  return Operator("BlockGrad")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Apply a sparse regularization to the output a sigmoid activation
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data.
+ * \param sparseness_target The sparseness target
+ * \param penalty The tradeoff parameter for the sparseness penalty
+ * \param momentum The momentum for running average
+ * \return new symbol
+ */
+inline Symbol IdentityAttachKLSparseReg(const std::string& symbol_name,
+                                        Symbol data,
+                                        mx_float sparseness_target = 0.1,
+                                        mx_float penalty = 0.001,
+                                        mx_float momentum = 0.9) {
+  return Operator("IdentityAttachKLSparseReg")
+           .SetParam("sparseness_target", sparseness_target)
+           .SetParam("penalty", penalty)
+           .SetParam("momentum", momentum)
            .SetInput("data", data)
            .CreateSymbol(symbol_name);
 }
@@ -2610,6 +2076,566 @@ inline Symbol UpSampling(const std::string& symbol_name,
 }
 
 /*!
+ * \breif Apply deconvolution to input then add a bias.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the DeconvolutionOp.
+ * \param weight Weight matrix.
+ * \param bias Bias parameter.
+ * \param kernel deconvolution kernel size: (y, x)
+ * \param num_filter deconvolution filter(channel) number
+ * \param stride deconvolution stride: (y, x)
+ * \param pad pad for deconvolution: (y, x), a good number is : (kernel-1)/2,
+ *        if target_shape set, pad will be ignored and will be computed
+ * \param adj adjustment for output shape: (y, x), if target_shape set, adj
+ * \param target_shape output shape with targe shape : (y, x)
+ * \param num_group number of groups partition
+ * \param workspace Tmp workspace for deconvolution (MB)
+ * \param no_bias Whether to disable bias parameter.
+ * \return new symbol
+ */
+inline Symbol Deconvolution(const std::string& symbol_name,
+                            Symbol data,
+                            Symbol weight,
+                            Symbol bias,
+                            Shape kernel,
+                            int num_filter,
+                            Shape stride = Shape(1,1),
+                            Shape pad = Shape(0,0),
+                            Shape adj = Shape(0,0),
+                            Shape target_shape = Shape(0,0),
+                            int num_group = 1,
+                            int64_t workspace = 512,
+                            bool no_bias = true) {
+  return Operator("Deconvolution")
+           .SetParam("kernel", kernel)
+           .SetParam("num_filter", num_filter)
+           .SetParam("stride", stride)
+           .SetParam("pad", pad)
+           .SetParam("adj", adj)
+           .SetParam("target_shape", target_shape)
+           .SetParam("num_group", num_group)
+           .SetParam("workspace", workspace)
+           .SetParam("no_bias", no_bias)
+           .SetInput("data", data)
+           .SetInput("weight", weight)
+           .SetInput("bias", bias)
+           .CreateSymbol(symbol_name);
+}
+
+/*! \breif Whether to pick convolution algo by running performance test.
+ *        Leads to higher startup time but may give faster speed. Options are:
+ *        'off': no tuning
+ *        'limited_workspace': run test and pick the fastest algorithm that
+ *        'fastest': pick the fastest algorithm and ignore workspace limit.
+ *        If set to None (default), behavior is determined by environment
+ *        variable MXNET_CUDNN_AUTOTUNE_DEFAULT: 0 for off,
+ *        1 for limited workspace (default), 2 for fastest.
+ */
+enum class ConvolutionCudnnTune {
+  None = 0,
+  fastest = 1,
+  limited_workspace = 2,
+  off = 3
+};
+
+/*! \breif Set layout for input, output and weight. Empty for
+ *        default layout: NCHW for 2d and NCDHW for 3d.
+ */
+enum class ConvolutionLayout {
+  None = 0,
+  NCDHW = 1,
+  NCHW = 2,
+  NDHWC = 3,
+  NHWC = 4
+};
+
+/*!
+ * \breif Apply convolution to input then add a bias.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the ConvolutionOp.
+ * \param weight Weight matrix.
+ * \param bias Bias parameter.
+ * \param kernel convolution kernel size: (h, w) or (d, h, w)
+ * \param num_filter convolution filter(channel) number
+ * \param stride convolution stride: (h, w) or (d, h, w)
+ * \param dilate convolution dilate: (h, w) or (d, h, w)
+ * \param pad pad for convolution: (h, w) or (d, h, w)
+ * \param num_group Number of group partitions. Equivalent to slicing input
+ *        partitions, apply convolution on each, then concatenate the results
+ * \param workspace Maximum tmp workspace allowed for convolution (MB).
+ * \param no_bias Whether to disable bias parameter.
+ * \param cudnn_tune Whether to pick convolution algo by running performance
+ *        Leads to higher startup time but may give faster speed. Options are:
+ *        'off': no tuning
+ *        'limited_workspace': run test and pick the fastest algorithm that
+ *        'fastest': pick the fastest algorithm and ignore workspace limit.
+ *        If set to None (default), behavior is determined by environment
+ *        variable MXNET_CUDNN_AUTOTUNE_DEFAULT: 0 for off,
+ *        1 for limited workspace (default), 2 for fastest.
+ * \param cudnn_off Turn off cudnn for this layer.
+ * \param layout Set layout for input, output and weight. Empty for
+ *        default layout: NCHW for 2d and NCDHW for 3d.
+ * \return new symbol
+ */
+inline Symbol Convolution(const std::string& symbol_name,
+                          Symbol data,
+                          Symbol weight,
+                          Symbol bias,
+                          Shape kernel,
+                          int num_filter,
+                          Shape stride = Shape(),
+                          Shape dilate = Shape(),
+                          Shape pad = Shape(),
+                          int num_group = 1,
+                          int64_t workspace = 1024,
+                          bool no_bias = false,
+                          ConvolutionCudnnTune cudnn_tune = ConvolutionCudnnTune::None,
+                          bool cudnn_off = false,
+                          ConvolutionLayout layout = ConvolutionLayout::None) {
+  static const char *ConvolutionCudnnTuneValues[] = {
+    "None",
+    "fastest",
+    "limited_workspace",
+    "off"
+  };
+  static const char *ConvolutionLayoutValues[] = {
+    "None",
+    "NCDHW",
+    "NCHW",
+    "NDHWC",
+    "NHWC"
+  };
+  return Operator("Convolution")
+           .SetParam("kernel", kernel)
+           .SetParam("num_filter", num_filter)
+           .SetParam("stride", stride)
+           .SetParam("dilate", dilate)
+           .SetParam("pad", pad)
+           .SetParam("num_group", num_group)
+           .SetParam("workspace", workspace)
+           .SetParam("no_bias", no_bias)
+           .SetParam("cudnn_tune", ConvolutionCudnnTuneValues[int(cudnn_tune)])
+           .SetParam("cudnn_off", cudnn_off)
+           .SetParam("layout", ConvolutionLayoutValues[int(layout)])
+           .SetInput("data", data)
+           .SetInput("weight", weight)
+           .SetInput("bias", bias)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Performs region-of-interest pooling on inputs. Resize bounding box
+ *        coordinates by spatial_scale and crop input feature maps
+ *        accordingly. The cropped feature maps are pooled by max pooling to a
+ *        fixed size output indicated by pooled_size. batch_size will change
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the pooling operator, a 4D Feature maps
+ * \param rois Bounding box coordinates, a 2D array of [[batch_index, x1, y1,
+ *        x2, y2]]. (x1, y1) and (x2, y2) are top left and down right corners
+ *        of designated region of interest. batch_index indicates the index of
+ * \param pooled_size fix pooled size: (h, w)
+ * \param spatial_scale Ratio of input feature map height (or w) to raw image
+ *        height (or w). Equals the reciprocal of total stride in
+ * \return new symbol
+ */
+inline Symbol ROIPooling(const std::string& symbol_name,
+                         Symbol data,
+                         Symbol rois,
+                         Shape pooled_size,
+                         mx_float spatial_scale) {
+  return Operator("ROIPooling")
+           .SetParam("pooled_size", pooled_size)
+           .SetParam("spatial_scale", spatial_scale)
+           .SetInput("data", data)
+           .SetInput("rois", rois)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Apply batch normalization to input.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to batch normalization
+ * \param eps Epsilon to prevent div 0
+ * \param momentum Momentum for moving average
+ * \param fix_gamma Fix gamma while training
+ * \param use_global_stats Whether use global moving statistics instead of
+ *        local batch-norm. This will force change batch-norm into a scale
+ * \return new symbol
+ */
+inline Symbol CuDNNBatchNorm(const std::string& symbol_name,
+                             Symbol data,
+                             mx_float eps = 0.001,
+                             mx_float momentum = 0.9,
+                             bool fix_gamma = true,
+                             bool use_global_stats = false) {
+  return Operator("CuDNNBatchNorm")
+           .SetParam("eps", eps)
+           .SetParam("momentum", momentum)
+           .SetParam("fix_gamma", fix_gamma)
+           .SetParam("use_global_stats", use_global_stats)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Apply matrix multiplication to input then add a bias.
+ *        It maps the input of shape `(batch_size, input_dim)` to the shape of
+ *        `(batch_size, num_hidden)`. Learnable parameters include the weights
+ *        of the linear transform and an optional bias vector.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the FullyConnectedOp.
+ * \param weight Weight matrix.
+ * \param bias Bias parameter.
+ * \param num_hidden Number of hidden nodes of the output.
+ * \param no_bias Whether to disable bias parameter.
+ * \return new symbol
+ */
+inline Symbol FullyConnected(const std::string& symbol_name,
+                             Symbol data,
+                             Symbol weight,
+                             Symbol bias,
+                             int num_hidden,
+                             bool no_bias = false) {
+  return Operator("FullyConnected")
+           .SetParam("num_hidden", num_hidden)
+           .SetParam("no_bias", no_bias)
+           .SetInput("data", data)
+           .SetInput("weight", weight)
+           .SetInput("bias", bias)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Use linear regression for final output, this is used on final output
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to function.
+ * \param label Input label to function.
+ * \param grad_scale Scale the gradient by a float factor
+ * \return new symbol
+ */
+inline Symbol LinearRegressionOutput(const std::string& symbol_name,
+                                     Symbol data,
+                                     Symbol label,
+                                     mx_float grad_scale = 1) {
+  return Operator("LinearRegressionOutput")
+           .SetParam("grad_scale", grad_scale)
+           .SetInput("data", data)
+           .SetInput("label", label)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Use mean absolute error regression for final output, this is used on
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to function.
+ * \param label Input label to function.
+ * \param grad_scale Scale the gradient by a float factor
+ * \return new symbol
+ */
+inline Symbol MAERegressionOutput(const std::string& symbol_name,
+                                  Symbol data,
+                                  Symbol label,
+                                  mx_float grad_scale = 1) {
+  return Operator("MAERegressionOutput")
+           .SetParam("grad_scale", grad_scale)
+           .SetInput("data", data)
+           .SetInput("label", label)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Use Logistic regression for final output, this is used on final
+ *        Logistic regression is suitable for binary classification or
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to function.
+ * \param label Input label to function.
+ * \param grad_scale Scale the gradient by a float factor
+ * \return new symbol
+ */
+inline Symbol LogisticRegressionOutput(const std::string& symbol_name,
+                                       Symbol data,
+                                       Symbol label,
+                                       mx_float grad_scale = 1) {
+  return Operator("LogisticRegressionOutput")
+           .SetParam("grad_scale", grad_scale)
+           .SetInput("data", data)
+           .SetInput("label", label)
+           .CreateSymbol(symbol_name);
+}
+
+/*! \breif If set to null, op will not normalize on output gradient.If set to
+ *        batch, op will normalize gradient by divide batch size.If set to
+ */
+enum class MakeLossNormalization {
+  batch = 0,
+  null = 1,
+  valid = 2
+};
+
+/*!
+ * \breif Get output from a symbol and pass 1 gradient back. This is used as a
+ *        terminal loss if unary and binary operator are used to composite a
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data.
+ * \param grad_scale gradient scale as a supplement to unary and binary
+ * \param valid_thresh regard element valid when x > valid_thresh, this is used
+ * \param normalization If set to null, op will not normalize on output
+ *        gradient.If set to batch, op will normalize gradient by divide batch
+ *        size.If set to valid, op will normalize gradient by divide # sample
+ * \return new symbol
+ */
+inline Symbol MakeLoss(const std::string& symbol_name,
+                       Symbol data,
+                       mx_float grad_scale = 1,
+                       mx_float valid_thresh = 0,
+                       MakeLossNormalization normalization = MakeLossNormalization::null) {
+  static const char *MakeLossNormalizationValues[] = {
+    "batch",
+    "null",
+    "valid"
+  };
+  return Operator("MakeLoss")
+           .SetParam("grad_scale", grad_scale)
+           .SetParam("valid_thresh", valid_thresh)
+           .SetParam("normalization", MakeLossNormalizationValues[int(normalization)])
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Slice input equally along specified axis
+ * \param symbol_name name of the resulting symbol
+ * \param num_outputs Number of outputs to be sliced.
+ * \param axis Dimension along which to slice.
+ * \param squeeze_axis If true AND the sliced dimension becomes 1, squeeze that
+ * \return new symbol
+ */
+inline Symbol SliceChannel(const std::string& symbol_name,
+                           int num_outputs,
+                           int axis = 1,
+                           bool squeeze_axis = false) {
+  return Operator("SliceChannel")
+           .SetParam("num_outputs", num_outputs)
+           .SetParam("axis", axis)
+           .SetParam("squeeze_axis", squeeze_axis)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Perform a feature concat on channel dim (defaut is 1) over all
+ * \param symbol_name name of the resulting symbol
+ * \param data List of tensors to concatenate
+ * \param num_args Number of inputs to be concated.
+ * \param dim the dimension to be concated.
+ * \return new symbol
+ */
+inline Symbol Concat(const std::string& symbol_name,
+                     const std::vector<Symbol>& data,
+                     int num_args,
+                     int dim = 1) {
+  return Operator("Concat")
+           .SetParam("num_args", num_args)
+           .SetParam("dim", dim)
+(data)
+           .CreateSymbol(symbol_name);
+}
+
+/*! \breif Activation function to be applied.
+ */
+enum class ActivationActType {
+  relu = 0,
+  sigmoid = 1,
+  softrelu = 2,
+  tanh = 3
+};
+
+/*!
+ * \breif Elementwise activation function.
+ *
+ *        The following activation types are supported (operations are applied
+ *        scalar of the input tensor):
+ *
+ *        - `relu`: Rectified Linear Unit, `y = max(x, 0)`
+ *        - `sigmoid`: `y = 1 / (1 + exp(-x))`
+ *        - `tanh`: Hyperbolic tangent, `y = (exp(x) - exp(-x)) / (exp(x) +
+ *        - `softrelu`: Soft ReLU, or SoftPlus, `y = log(1 + exp(x))`
+ *
+ *        See `LeakyReLU` for other activations with parameters.
+ *
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to activation function.
+ * \param act_type Activation function to be applied.
+ * \return new symbol
+ */
+inline Symbol Activation(const std::string& symbol_name,
+                         Symbol data,
+                         ActivationActType act_type) {
+  static const char *ActivationActTypeValues[] = {
+    "relu",
+    "sigmoid",
+    "softrelu",
+    "tanh"
+  };
+  return Operator("Activation")
+           .SetParam("act_type", ActivationActTypeValues[int(act_type)])
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Custom operator implemented in frontend.
+ * \param symbol_name name of the resulting symbol
+ * \param op_type Type of custom operator. Must be registered first.
+ * \return new symbol
+ */
+inline Symbol Custom(const std::string& symbol_name,
+                     const std::string& op_type) {
+  return Operator("Custom")
+           .CreateSymbol(symbol_name);
+}
+
+/*! \breif Pooling type to be applied.
+ */
+enum class PoolingPoolType {
+  avg = 0,
+  max = 1,
+  sum = 2
+};
+
+/*! \breif Pooling convention to be applied.kValid is default setting of Mxnet
+ *        and rounds down the output pooling size.kFull is compatible with
+ */
+enum class PoolingPoolingConvention {
+  full = 0,
+  valid = 1
+};
+
+/*!
+ * \breif Perform spatial pooling on inputs.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the pooling operator.
+ * \param kernel pooling kernel size: (y, x) or (d, y, x)
+ * \param pool_type Pooling type to be applied.
+ * \param global_pool Ignore kernel size, do global pooling based on current
+ * \param pooling_convention Pooling convention to be applied.kValid is default
+ *        setting of Mxnet and rounds down the output pooling size.kFull is
+ * \param stride stride: for pooling (y, x) or (d, y, x)
+ * \param pad pad for pooling: (y, x) or (d, y, x)
+ * \return new symbol
+ */
+inline Symbol Pooling(const std::string& symbol_name,
+                      Symbol data,
+                      Shape kernel,
+                      PoolingPoolType pool_type,
+                      bool global_pool = false,
+                      PoolingPoolingConvention pooling_convention = PoolingPoolingConvention::valid,
+                      Shape stride = Shape(1,1),
+                      Shape pad = Shape(0,0)) {
+  static const char *PoolingPoolTypeValues[] = {
+    "avg",
+    "max",
+    "sum"
+  };
+  static const char *PoolingPoolingConventionValues[] = {
+    "full",
+    "valid"
+  };
+  return Operator("Pooling")
+           .SetParam("kernel", kernel)
+           .SetParam("pool_type", PoolingPoolTypeValues[int(pool_type)])
+           .SetParam("global_pool", global_pool)
+           .SetParam("pooling_convention", PoolingPoolingConventionValues[int(pooling_convention)])
+           .SetParam("stride", stride)
+           .SetParam("pad", pad)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Apply batch normalization to input.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to batch normalization
+ * \param eps Epsilon to prevent div 0
+ * \param momentum Momentum for moving average
+ * \param fix_gamma Fix gamma while training
+ * \param use_global_stats Whether use global moving statistics instead of
+ *        local batch-norm. This will force change batch-norm into a scale
+ * \return new symbol
+ */
+inline Symbol BatchNorm(const std::string& symbol_name,
+                        Symbol data,
+                        mx_float eps = 0.001,
+                        mx_float momentum = 0.9,
+                        bool fix_gamma = true,
+                        bool use_global_stats = false) {
+  return Operator("BatchNorm")
+           .SetParam("eps", eps)
+           .SetParam("momentum", momentum)
+           .SetParam("fix_gamma", fix_gamma)
+           .SetParam("use_global_stats", use_global_stats)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Apply dropout to input.
+ *        During training, each element of the input is randomly set to zero
+ *        And then the whole tensor is rescaled by 1/(1-p) to keep the
+ *        before applying dropout. During the test time, this behaves as an
+ *
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to dropout.
+ * \param p Fraction of the input that gets dropped out at training time
+ * \return new symbol
+ */
+inline Symbol Dropout(const std::string& symbol_name,
+                      Symbol data,
+                      mx_float p = 0.5) {
+  return Operator("Dropout")
+           .SetParam("p", p)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*! \breif Softmax Mode. If set to instance, this operator will compute a
+ *        softmax for each instance in the batch; this is the default mode. If
+ *        set to channel, this operator will compute a num_channel-class
+ *        softmax at each position of each instance; this can be used for
+ */
+enum class SoftmaxActivationMode {
+  channel = 0,
+  instance = 1
+};
+
+/*!
+ * \breif Apply softmax activation to input. This is intended for internal
+ *        layers. For output (loss layer) please use SoftmaxOutput. If
+ *        mode=instance, this operator will compute a softmax for each
+ *        instance in the batch; this is the default mode. If mode=channel,
+ *        this operator will compute a num_channel-class softmax at each
+ *        position of each instance; this can be used for fully convolutional
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to activation function.
+ * \param mode Softmax Mode. If set to instance, this operator will compute a
+ *        softmax for each instance in the batch; this is the default mode. If
+ *        set to channel, this operator will compute a num_channel-class
+ *        softmax at each position of each instance; this can be used for
+ * \return new symbol
+ */
+inline Symbol SoftmaxActivation(const std::string& symbol_name,
+                                Symbol data,
+                                SoftmaxActivationMode mode = SoftmaxActivationMode::instance) {
+  static const char *SoftmaxActivationModeValues[] = {
+    "channel",
+    "instance"
+  };
+  return Operator("SoftmaxActivation")
+           .SetParam("mode", SoftmaxActivationModeValues[int(mode)])
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
  * \breif Choose one element from each line(row for python, column for R/Julia)
  *        in lhs according to index indicated by rhs. This function assume rhs
  * \param symbol_name name of the resulting symbol
@@ -2663,6 +2689,360 @@ inline Symbol clip(const std::string& symbol_name,
            .SetParam("a_max", a_max)
            .SetInput("src", src)
            .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_add(Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_add")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_sub(Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_sub")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_mul(Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_mul")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_div(Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_div")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Reshape input according to a target shape spec.
+ *        The target shape is a tuple and can be a simple list of dimensions
+ *        such as (12,3) or it can incorporate special codes that correspond
+ *        The special codes are all expressed as integers less than 1. These
+ *        codes effectively refer to a machine that pops input dims off the
+ *        beginning of the input dims list and pushes resulting output dims
+ *        onto the end of the output dims list, which starts empty. The codes
+ *        0  Copy     Pop one input dim and push it onto the output dims
+ *        -1  Infer    Push a dim that is inferred later from all other output
+ *        -2  CopyAll  Pop all remaining input dims and push them onto output
+ *        -3  Merge2   Pop two input dims, multiply them, and push result
+ *        -4  Split2   Pop one input dim, and read two next target shape specs,
+ *        push them both onto output dims (either can be -1 and will
+ *        be inferred from the other
+ *        The exact mathematical behavior of these codes is given in the
+ *        description of the 'shape' parameter. All non-codes (positive
+ *        integers) just pop a dim off the input dims (if any), throw it away,
+ *        Examples:
+ *        Type     Input      Target            Output
+ *        Copy     (2,3,4)    (4,0,2)           (4,3,2)
+ *        Copy     (2,3,4)    (2,0,0)           (2,3,4)
+ *        Infer    (2,3,4)    (6,1,-1)          (6,1,4)
+ *        Infer    (2,3,4)    (3,-1,8)          (3,1,8)
+ *        CopyAll  (9,8,7)    (-2)              (9,8,7)
+ *        CopyAll  (9,8,7)    (9,-2)            (9,8,7)
+ *        CopyAll  (9,8,7)    (-2,1,1)          (9,8,7,1,1)
+ *        Merge2   (3,4)      (-3)              (12)
+ *        Merge2   (3,4,5)    (-3,0)            (12,5)
+ *        Merge2   (3,4,5)    (0,-3)            (3,20)
+ *        Merge2   (3,4,5,6)  (-3,0,0)          (12,5,6)
+ *        Merge2   (3,4,5,6)  (-3,-2)           (12,5,6)
+ *        Split2   (12)       (-4,6,2)          (6,2)
+ *        Split2   (12)       (-4,2,6)          (2,6)
+ *        Split2   (12)       (-4,-1,6)         (2,6)
+ *        Split2   (12,9)     (-4,2,6,0)        (2,6,9)
+ *        Split2   (12,9,9,9) (-4,2,6,-2)       (2,6,9,9,9)
+ *        Split2   (12,12)    (-4,2,-1,-4,-1,2) (2,6,6,2)
+ *
+ *
+ *        From:src/operator/tensor/matrix_op.cc:61
+ * \param data Input data to reshape.
+ * \param target_shape (Deprecated! Use shape instead.) Target new shape. One
+ *        and only one dim can be 0, in which case it will be inferred from
+ * \param keep_highest (Deprecated! Use shape instead.) Whether keep the
+ *        highest dim unchanged.If set to true, then the first dim in
+ * \param shape Target shape, a tuple, t=(t_1,t_2,..,t_m).
+ *        Let the input dims be s=(s_1,s_2,..,s_n).
+ *        The output dims u=(u_1,u_2,..,u_p) are computed from s and t.
+ *        The target shape tuple elements t_i are read in order, and used to
+ *        t_i:       meaning:      behavior:
+ *        +ve        explicit      u_p = t_i
+ *        0          copy          u_p = s_i
+ *        -1         infer         u_p = (Prod s_i) / (Prod u_j | j != p)
+ *        -2         copy all      u_p = s_i, u_p+1 = s_i+1, ...
+ *        -3         merge two     u_p = s_i * s_i+1
+ *        -4,a,b     split two     u_p = a, u_p+1 = b | a * b = s_i
+ *        The split directive (-4) in the target shape tuple is followed by two
+ *        dimensions, one of which can be -1, which means it will be inferred
+ *        The can only be one globally inferred dimension (-1), aside from any
+ * \param reverse Whether to match the shapes from the backward. If reverse is
+ *        true, 0 values in the `shape` argument will be searched from the
+ *        backward. E.g the original shape is (10, 5, 4) and the shape
+ *        argument is (-1, 0). If reverse is true, the new shape should be
+ * \return new symbol
+ */
+inline Symbol Reshape(Symbol data,
+                      Shape target_shape = Shape(0,0),
+                      bool keep_highest = false,
+                      Shape shape = Shape(),
+                      bool reverse = false) {
+  return Operator("Reshape")
+           .SetParam("target_shape", target_shape)
+           .SetParam("keep_highest", keep_highest)
+           .SetParam("shape", shape)
+           .SetParam("reverse", reverse)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Flatten input into 2D by collapsing all the higher dimensions.
+ *        A (d1, d2, ..., dK) tensor is flatten to (d1, d2* ... *dK) matrix.
+ * \param data Input data to reshape.
+ * \return new symbol
+ */
+inline Symbol Flatten(Symbol data) {
+  return Operator("Flatten")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Transpose the input tensor and return a new one
+ *
+ *        From:src/operator/tensor/matrix_op.cc:93
+ * \param data Source input
+ * \param axes Target axis order. By default the axes will be inverted.
+ * \return new symbol
+ */
+inline Symbol transpose(Symbol data,
+                        Shape axes = Shape()) {
+  return Operator("transpose")
+           .SetParam("axes", axes)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Expand the shape of array by inserting a new axis.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:121
+ * \param data Source input
+ * \param axis Position (amongst axes) where new axis is to be inserted.
+ * \return new symbol
+ */
+inline Symbol expand_dims(Symbol data,
+                          int axis) {
+  return Operator("expand_dims")
+           .SetParam("axis", axis)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif (Crop the input tensor and return a new one.
+ *
+ *        Requirements
+ *        ------------
+ *        - the input and output (if explicitly given) are of the same data
+ *        and on the same device.
+ *        )
+ *
+ *        From:src/operator/tensor/matrix_op.cc:142
+ * \param data Source input
+ * \param begin starting coordinates
+ * \param end ending coordinates
+ * \return new symbol
+ */
+inline Symbol crop(Symbol data,
+                   Shape begin,
+                   Shape end) {
+  return Operator("crop")
+           .SetParam("begin", begin)
+           .SetParam("end", end)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Slice the input along certain axis and return a sliced array.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:197
+ * \param data Source input
+ * \param axis The axis to be sliced
+ * \param begin The beginning index to be sliced
+ * \param end The end index to be sliced
+ * \return new symbol
+ */
+inline Symbol slice_axis(Symbol data,
+                         int axis,
+                         int begin,
+                         int end) {
+  return Operator("slice_axis")
+           .SetParam("axis", axis)
+           .SetParam("begin", begin)
+           .SetParam("end", end)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Flip the input tensor along axis and return a new one.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:216
+ * \param data Source input
+ * \param axis The dimension to flip
+ * \return new symbol
+ */
+inline Symbol flip(Symbol data,
+                   int axis) {
+  return Operator("flip")
+           .SetParam("axis", axis)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Calculate dot product of two matrices or two vectors.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:228
+ * \param lhs Left input
+ * \param rhs Right input
+ * \param transpose_a True if the first matrix is transposed.
+ * \param transpose_b True if the second matrix is tranposed.
+ * \return new symbol
+ */
+inline Symbol dot(Symbol lhs,
+                  Symbol rhs,
+                  bool transpose_a = false,
+                  bool transpose_b = false) {
+  return Operator("dot")
+           .SetParam("transpose_a", transpose_a)
+           .SetParam("transpose_b", transpose_b)
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Calculate batched dot product of two matrices. (batch, M, K)
+ *
+ *        From:src/operator/tensor/matrix_op.cc:254
+ * \param lhs Left input
+ * \param rhs Right input
+ * \param axis The dimension to flip
+ * \return new symbol
+ */
+inline Symbol batch_dot(Symbol lhs,
+                        Symbol rhs,
+                        int axis) {
+  return Operator("batch_dot")
+           .SetParam("axis", axis)
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol elemwise_add(Symbol lhs,
+                           Symbol rhs) {
+  return Operator("elemwise_add")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_power(Symbol lhs,
+                              Symbol rhs) {
+  return Operator("broadcast_power")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_maximum(Symbol lhs,
+                                Symbol rhs) {
+  return Operator("broadcast_maximum")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_minimum(Symbol lhs,
+                                Symbol rhs) {
+  return Operator("broadcast_minimum")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_hypot(Symbol lhs,
+                              Symbol rhs) {
+  return Operator("broadcast_hypot")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
 }
 
 /*!
@@ -2873,245 +3253,6 @@ inline Symbol broadcast_to(Symbol data,
 inline Symbol norm(Symbol src) {
   return Operator("norm")
            .SetInput("src", src)
-           .CreateSymbol();
-}
-
-/*!
- * \breif
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_add(Symbol lhs,
-                            Symbol rhs) {
-  return Operator("broadcast_add")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_sub(Symbol lhs,
-                            Symbol rhs) {
-  return Operator("broadcast_sub")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_mul(Symbol lhs,
-                            Symbol rhs) {
-  return Operator("broadcast_mul")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_div(Symbol lhs,
-                            Symbol rhs) {
-  return Operator("broadcast_div")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_power(Symbol lhs,
-                              Symbol rhs) {
-  return Operator("broadcast_power")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_maximum(Symbol lhs,
-                                Symbol rhs) {
-  return Operator("broadcast_maximum")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_minimum(Symbol lhs,
-                                Symbol rhs) {
-  return Operator("broadcast_minimum")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_hypot(Symbol lhs,
-                              Symbol rhs) {
-  return Operator("broadcast_hypot")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_equal(Symbol lhs,
-                              Symbol rhs) {
-  return Operator("broadcast_equal")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_not_equal(Symbol lhs,
-                                  Symbol rhs) {
-  return Operator("broadcast_not_equal")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_greater(Symbol lhs,
-                                Symbol rhs) {
-  return Operator("broadcast_greater")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_greater_equal(Symbol lhs,
-                                      Symbol rhs) {
-  return Operator("broadcast_greater_equal")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_lesser(Symbol lhs,
-                               Symbol rhs) {
-  return Operator("broadcast_lesser")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol broadcast_lesser_equal(Symbol lhs,
-                                     Symbol rhs) {
-  return Operator("broadcast_lesser_equal")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif
- * \param lhs first input
- * \param rhs second input
- * \return new symbol
- */
-inline Symbol elemwise_add(Symbol lhs,
-                           Symbol rhs) {
-  return Operator("elemwise_add")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Calculate Smooth L1 Loss(lhs, scalar)
- *
- *        From:src/operator/tensor/elemwise_binary_scalar_op_extended.cc:63
- * \param data source input
- * \param scalar scalar input
- * \return new symbol
- */
-inline Symbol smooth_l1(Symbol data,
-                        mx_float scalar) {
-  return Operator("smooth_l1")
-           .SetParam("scalar", scalar)
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Perform element sum of inputs
- *
- *        From:src/operator/tensor/elemwise_sum.cc:56
- * \param args List of input tensors
- * \return new symbol
- */
-inline Symbol ElementWiseSum(const std::vector<Symbol>& args) {
-  return Operator("ElementWiseSum")
-(args)
            .CreateSymbol();
 }
 
@@ -3545,6 +3686,22 @@ inline Symbol gammaln(Symbol data) {
 }
 
 /*!
+ * \breif Calculate Smooth L1 Loss(lhs, scalar)
+ *
+ *        From:src/operator/tensor/elemwise_binary_scalar_op_extended.cc:63
+ * \param data source input
+ * \param scalar scalar input
+ * \return new symbol
+ */
+inline Symbol smooth_l1(Symbol data,
+                        mx_float scalar) {
+  return Operator("smooth_l1")
+           .SetParam("scalar", scalar)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
  * \breif Map integer index to vector representations (embeddings). Those
  *        embeddings are learnable parameters. For a input of shape (d1, ...,
  *        dK), the output shape is (d1, ..., dK, output_dim). All the input
@@ -3569,228 +3726,84 @@ inline Symbol Embedding(Symbol data,
 }
 
 /*!
- * \breif Reshape input according to a target shape spec.
- *        The target shape is a tuple and can be a simple list of dimensions
- *        such as (12,3) or it can incorporate special codes that correspond
- *        The special codes are all expressed as integers less than 1. These
- *        codes effectively refer to a machine that pops input dims off the
- *        beginning of the input dims list and pushes resulting output dims
- *        onto the end of the output dims list, which starts empty. The codes
- *        0  Copy     Pop one input dim and push it onto the output dims
- *        -1  Infer    Push a dim that is inferred later from all other output
- *        -2  CopyAll  Pop all remaining input dims and push them onto output
- *        -3  Merge2   Pop two input dims, multiply them, and push result
- *        -4  Split2   Pop one input dim, and read two next target shape specs,
- *        push them both onto output dims (either can be -1 and will
- *        be inferred from the other
- *        The exact mathematical behavior of these codes is given in the
- *        description of the 'shape' parameter. All non-codes (positive
- *        integers) just pop a dim off the input dims (if any), throw it away,
- *        Examples:
- *        Type     Input      Target            Output
- *        Copy     (2,3,4)    (4,0,2)           (4,3,2)
- *        Copy     (2,3,4)    (2,0,0)           (2,3,4)
- *        Infer    (2,3,4)    (6,1,-1)          (6,1,4)
- *        Infer    (2,3,4)    (3,-1,8)          (3,1,8)
- *        CopyAll  (9,8,7)    (-2)              (9,8,7)
- *        CopyAll  (9,8,7)    (9,-2)            (9,8,7)
- *        CopyAll  (9,8,7)    (-2,1,1)          (9,8,7,1,1)
- *        Merge2   (3,4)      (-3)              (12)
- *        Merge2   (3,4,5)    (-3,0)            (12,5)
- *        Merge2   (3,4,5)    (0,-3)            (3,20)
- *        Merge2   (3,4,5,6)  (-3,0,0)          (12,5,6)
- *        Merge2   (3,4,5,6)  (-3,-2)           (12,5,6)
- *        Split2   (12)       (-4,6,2)          (6,2)
- *        Split2   (12)       (-4,2,6)          (2,6)
- *        Split2   (12)       (-4,-1,6)         (2,6)
- *        Split2   (12,9)     (-4,2,6,0)        (2,6,9)
- *        Split2   (12,9,9,9) (-4,2,6,-2)       (2,6,9,9,9)
- *        Split2   (12,12)    (-4,2,-1,-4,-1,2) (2,6,6,2)
- *
- *
- *        From:src/operator/tensor/matrix_op.cc:61
- * \param data Input data to reshape.
- * \param target_shape (Deprecated! Use shape instead.) Target new shape. One
- *        and only one dim can be 0, in which case it will be inferred from
- * \param keep_highest (Deprecated! Use shape instead.) Whether keep the
- *        highest dim unchanged.If set to true, then the first dim in
- * \param shape Target shape, a tuple, t=(t_1,t_2,..,t_m).
- *        Let the input dims be s=(s_1,s_2,..,s_n).
- *        The output dims u=(u_1,u_2,..,u_p) are computed from s and t.
- *        The target shape tuple elements t_i are read in order, and used to
- *        t_i:       meaning:      behavior:
- *        +ve        explicit      u_p = t_i
- *        0          copy          u_p = s_i
- *        -1         infer         u_p = (Prod s_i) / (Prod u_j | j != p)
- *        -2         copy all      u_p = s_i, u_p+1 = s_i+1, ...
- *        -3         merge two     u_p = s_i * s_i+1
- *        -4,a,b     split two     u_p = a, u_p+1 = b | a * b = s_i
- *        The split directive (-4) in the target shape tuple is followed by two
- *        dimensions, one of which can be -1, which means it will be inferred
- *        The can only be one globally inferred dimension (-1), aside from any
- * \param reverse Whether to match the shapes from the backward. If reverse is
- *        true, 0 values in the `shape` argument will be searched from the
- *        backward. E.g the original shape is (10, 5, 4) and the shape
- *        argument is (-1, 0). If reverse is true, the new shape should be
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
  * \return new symbol
  */
-inline Symbol Reshape(Symbol data,
-                      Shape target_shape = Shape(0,0),
-                      bool keep_highest = false,
-                      Shape shape = Shape(),
-                      bool reverse = false) {
-  return Operator("Reshape")
-           .SetParam("target_shape", target_shape)
-           .SetParam("keep_highest", keep_highest)
-           .SetParam("shape", shape)
-           .SetParam("reverse", reverse)
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Flatten input into 2D by collapsing all the higher dimensions.
- *        A (d1, d2, ..., dK) tensor is flatten to (d1, d2* ... *dK) matrix.
- * \param data Input data to reshape.
- * \return new symbol
- */
-inline Symbol Flatten(Symbol data) {
-  return Operator("Flatten")
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Transpose the input tensor and return a new one
- *
- *        From:src/operator/tensor/matrix_op.cc:93
- * \param data Source input
- * \param axes Target axis order. By default the axes will be inverted.
- * \return new symbol
- */
-inline Symbol transpose(Symbol data,
-                        Shape axes = Shape()) {
-  return Operator("transpose")
-           .SetParam("axes", axes)
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Expand the shape of array by inserting a new axis.
- *
- *        From:src/operator/tensor/matrix_op.cc:121
- * \param data Source input
- * \param axis Position (amongst axes) where new axis is to be inserted.
- * \return new symbol
- */
-inline Symbol expand_dims(Symbol data,
-                          int axis) {
-  return Operator("expand_dims")
-           .SetParam("axis", axis)
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif (Crop the input tensor and return a new one.
- *
- *        Requirements
- *        ------------
- *        - the input and output (if explicitly given) are of the same data
- *        and on the same device.
- *        )
- *
- *        From:src/operator/tensor/matrix_op.cc:142
- * \param data Source input
- * \param begin starting coordinates
- * \param end ending coordinates
- * \return new symbol
- */
-inline Symbol crop(Symbol data,
-                   Shape begin,
-                   Shape end) {
-  return Operator("crop")
-           .SetParam("begin", begin)
-           .SetParam("end", end)
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Slice the input along certain axis and return a sliced array.
- *
- *        From:src/operator/tensor/matrix_op.cc:197
- * \param data Source input
- * \param axis The axis to be sliced
- * \param begin The beginning index to be sliced
- * \param end The end index to be sliced
- * \return new symbol
- */
-inline Symbol slice_axis(Symbol data,
-                         int axis,
-                         int begin,
-                         int end) {
-  return Operator("slice_axis")
-           .SetParam("axis", axis)
-           .SetParam("begin", begin)
-           .SetParam("end", end)
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Flip the input tensor along axis and return a new one.
- *
- *        From:src/operator/tensor/matrix_op.cc:216
- * \param data Source input
- * \param axis The dimension to flip
- * \return new symbol
- */
-inline Symbol flip(Symbol data,
-                   int axis) {
-  return Operator("flip")
-           .SetParam("axis", axis)
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Calculate dot product of two matrices or two vectors.
- *
- *        From:src/operator/tensor/matrix_op.cc:228
- * \param lhs Left input
- * \param rhs Right input
- * \param transpose_a True if the first matrix is transposed.
- * \param transpose_b True if the second matrix is tranposed.
- * \return new symbol
- */
-inline Symbol dot(Symbol lhs,
-                  Symbol rhs,
-                  bool transpose_a = false,
-                  bool transpose_b = false) {
-  return Operator("dot")
-           .SetParam("transpose_a", transpose_a)
-           .SetParam("transpose_b", transpose_b)
+inline Symbol broadcast_equal(Symbol lhs,
+                              Symbol rhs) {
+  return Operator("broadcast_equal")
            .SetInput("lhs", lhs)
            .SetInput("rhs", rhs)
            .CreateSymbol();
 }
 
 /*!
- * \breif Calculate batched dot product of two matrices. (batch, M, K)
- *
- *        From:src/operator/tensor/matrix_op.cc:254
- * \param lhs Left input
- * \param rhs Right input
- * \param axis The dimension to flip
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
  * \return new symbol
  */
-inline Symbol batch_dot(Symbol lhs,
-                        Symbol rhs,
-                        int axis) {
-  return Operator("batch_dot")
-           .SetParam("axis", axis)
+inline Symbol broadcast_not_equal(Symbol lhs,
+                                  Symbol rhs) {
+  return Operator("broadcast_not_equal")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_greater(Symbol lhs,
+                                Symbol rhs) {
+  return Operator("broadcast_greater")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_greater_equal(Symbol lhs,
+                                      Symbol rhs) {
+  return Operator("broadcast_greater_equal")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_lesser(Symbol lhs,
+                               Symbol rhs) {
+  return Operator("broadcast_lesser")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_lesser_equal(Symbol lhs,
+                                     Symbol rhs) {
+  return Operator("broadcast_lesser_equal")
            .SetInput("lhs", lhs)
            .SetInput("rhs", rhs)
            .CreateSymbol();
@@ -3835,18 +3848,15 @@ inline Symbol normal(mx_float loc = 0,
 }
 
 /*!
- * \breif Calculate cross_entropy(lhs, one_hot(rhs))
+ * \breif Perform element sum of inputs
  *
- *        From:src/operator/loss_binary_op.cc:12
- * \param data Input data
- * \param label Input label
+ *        From:src/operator/tensor/elemwise_sum.cc:56
+ * \param args List of input tensors
  * \return new symbol
  */
-inline Symbol softmax_cross_entropy(Symbol data,
-                                    Symbol label) {
-  return Operator("softmax_cross_entropy")
-           .SetInput("data", data)
-           .SetInput("label", label)
+inline Symbol ElementWiseSum(const std::vector<Symbol>& args) {
+  return Operator("ElementWiseSum")
+(args)
            .CreateSymbol();
 }
 
@@ -3878,356 +3888,18 @@ inline Symbol adam_update() {
 }
 
 /*!
- * \breif Elementwise activation function.
+ * \breif Calculate cross_entropy(lhs, one_hot(rhs))
  *
- *        The following activation types are supported (operations are applied
- *        scalar of the input tensor):
- *
- *        - `relu`: Rectified Linear Unit, `y = max(x, 0)`
- *        - `sigmoid`: `y = 1 / (1 + exp(-x))`
- *        - `tanh`: Hyperbolic tangent, `y = (exp(x) - exp(-x)) / (exp(x) +
- *        - `softrelu`: Soft ReLU, or SoftPlus, `y = log(1 + exp(x))`
- *
- *        See `LeakyReLU` for other activations with parameters.
- *
- * \param data Input data to activation function.
- * \param act_type Activation function to be applied.
+ *        From:src/operator/loss_binary_op.cc:12
+ * \param data Input data
+ * \param label Input label
  * \return new symbol
  */
-inline Symbol Activation(Symbol data,
-                         ActivationActType act_type) {
-  static const char *ActivationActTypeValues[] = {
-    "relu",
-    "sigmoid",
-    "softrelu",
-    "tanh"
-  };
-  return Operator("Activation")
-           .SetParam("act_type", ActivationActTypeValues[int(act_type)])
+inline Symbol softmax_cross_entropy(Symbol data,
+                                    Symbol label) {
+  return Operator("softmax_cross_entropy")
            .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Apply batch normalization to input.
- * \param data Input data to batch normalization
- * \param eps Epsilon to prevent div 0
- * \param momentum Momentum for moving average
- * \param fix_gamma Fix gamma while training
- * \param use_global_stats Whether use global moving statistics instead of
- *        local batch-norm. This will force change batch-norm into a scale
- * \return new symbol
- */
-inline Symbol BatchNorm(Symbol data,
-                        mx_float eps = 0.001,
-                        mx_float momentum = 0.9,
-                        bool fix_gamma = true,
-                        bool use_global_stats = false) {
-  return Operator("BatchNorm")
-           .SetParam("eps", eps)
-           .SetParam("momentum", momentum)
-           .SetParam("fix_gamma", fix_gamma)
-           .SetParam("use_global_stats", use_global_stats)
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Get output from a symbol and pass 0 gradient back
- * \param data Input data.
- * \return new symbol
- */
-inline Symbol BlockGrad(Symbol data) {
-  return Operator("BlockGrad")
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Cast array to a different data type.
- * \param data Input data to cast function.
- * \param dtype Target data type.
- * \return new symbol
- */
-inline Symbol Cast(Symbol data,
-                   CastDtype dtype) {
-  static const char *CastDtypeValues[] = {
-    "float16",
-    "float32",
-    "float64",
-    "int32",
-    "uint8"
-  };
-  return Operator("Cast")
-           .SetParam("dtype", CastDtypeValues[int(dtype)])
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Perform a feature concat on channel dim (defaut is 1) over all
- * \param data List of tensors to concatenate
- * \param num_args Number of inputs to be concated.
- * \param dim the dimension to be concated.
- * \return new symbol
- */
-inline Symbol Concat(const std::vector<Symbol>& data,
-                     int num_args,
-                     int dim = 1) {
-  return Operator("Concat")
-           .SetParam("num_args", num_args)
-           .SetParam("dim", dim)
-(data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Apply convolution to input then add a bias.
- * \param data Input data to the ConvolutionOp.
- * \param weight Weight matrix.
- * \param bias Bias parameter.
- * \param kernel convolution kernel size: (h, w) or (d, h, w)
- * \param num_filter convolution filter(channel) number
- * \param stride convolution stride: (h, w) or (d, h, w)
- * \param dilate convolution dilate: (h, w) or (d, h, w)
- * \param pad pad for convolution: (h, w) or (d, h, w)
- * \param num_group Number of group partitions. Equivalent to slicing input
- *        partitions, apply convolution on each, then concatenate the results
- * \param workspace Maximum tmp workspace allowed for convolution (MB).
- * \param no_bias Whether to disable bias parameter.
- * \param cudnn_tune Whether to pick convolution algo by running performance
- *        Leads to higher startup time but may give faster speed. Options are:
- *        'off': no tuning
- *        'limited_workspace': run test and pick the fastest algorithm that
- *        'fastest': pick the fastest algorithm and ignore workspace limit.
- *        If set to None (default), behavior is determined by environment
- *        variable MXNET_CUDNN_AUTOTUNE_DEFAULT: 0 for off,
- *        1 for limited workspace (default), 2 for fastest.
- * \param cudnn_off Turn off cudnn for this layer.
- * \param layout Set layout for input, output and weight. Empty for
- *        default layout: NCHW for 2d and NCDHW for 3d.
- * \return new symbol
- */
-inline Symbol Convolution(Symbol data,
-                          Symbol weight,
-                          Symbol bias,
-                          Shape kernel,
-                          int num_filter,
-                          Shape stride = Shape(),
-                          Shape dilate = Shape(),
-                          Shape pad = Shape(),
-                          int num_group = 1,
-                          int64_t workspace = 1024,
-                          bool no_bias = false,
-                          ConvolutionCudnnTune cudnn_tune = ConvolutionCudnnTune::None,
-                          bool cudnn_off = false,
-                          ConvolutionLayout layout = ConvolutionLayout::None) {
-  static const char *ConvolutionCudnnTuneValues[] = {
-    "None",
-    "fastest",
-    "limited_workspace",
-    "off"
-  };
-  static const char *ConvolutionLayoutValues[] = {
-    "None",
-    "NCDHW",
-    "NCHW",
-    "NDHWC",
-    "NHWC"
-  };
-  return Operator("Convolution")
-           .SetParam("kernel", kernel)
-           .SetParam("num_filter", num_filter)
-           .SetParam("stride", stride)
-           .SetParam("dilate", dilate)
-           .SetParam("pad", pad)
-           .SetParam("num_group", num_group)
-           .SetParam("workspace", workspace)
-           .SetParam("no_bias", no_bias)
-           .SetParam("cudnn_tune", ConvolutionCudnnTuneValues[int(cudnn_tune)])
-           .SetParam("cudnn_off", cudnn_off)
-           .SetParam("layout", ConvolutionLayoutValues[int(layout)])
-           .SetInput("data", data)
-           .SetInput("weight", weight)
-           .SetInput("bias", bias)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Apply correlation to inputs
- * \param data1 Input data1 to the correlation.
- * \param data2 Input data2 to the correlation.
- * \param kernel_size kernel size for Correlation must be an odd number
- * \param max_displacement Max displacement of Correlation
- * \param stride1 stride1 quantize data1 globally
- * \param stride2 stride2 quantize data2 within the neighborhood centered
- * \param pad_size pad for Correlation
- * \param is_multiply operation type is either multiplication or subduction
- * \return new symbol
- */
-inline Symbol Correlation(Symbol data1,
-                          Symbol data2,
-                          int kernel_size = 1,
-                          int max_displacement = 1,
-                          int stride1 = 1,
-                          int stride2 = 1,
-                          int pad_size = 0,
-                          bool is_multiply = true) {
-  return Operator("Correlation")
-           .SetParam("kernel_size", kernel_size)
-           .SetParam("max_displacement", max_displacement)
-           .SetParam("stride1", stride1)
-           .SetParam("stride2", stride2)
-           .SetParam("pad_size", pad_size)
-           .SetParam("is_multiply", is_multiply)
-           .SetInput("data1", data1)
-           .SetInput("data2", data2)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Crop the 2nd and 3rd dim of input data, with the corresponding size
- *        of h_w or with width and height of the second input symbol, i.e.,
- *        with one input, we need h_w to specify the crop height and width,
- * \param data Tensor or List of Tensors, the second input will be used as
- * \param num_args Number of inputs for crop, if equals one, then we will use
- *        the h_wfor crop height and width, else if equals two, then we will
- *        use the heightand width of the second input symbol, we name
- * \param offset crop offset coordinate: (y, x)
- * \param h_w crop height and weight: (h, w)
- * \param center_crop If set to true, then it will use be the center_crop,or it
- * \return new symbol
- */
-inline Symbol Crop(Symbol data,
-                   int num_args,
-                   Shape offset = Shape(0,0),
-                   Shape h_w = Shape(0,0),
-                   bool center_crop = false) {
-  return Operator("Crop")
-           .SetParam("num_args", num_args)
-           .SetParam("offset", offset)
-           .SetParam("h_w", h_w)
-           .SetParam("center_crop", center_crop)
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Custom operator implemented in frontend.
- * \param op_type Type of custom operator. Must be registered first.
- * \return new symbol
- */
-inline Symbol Custom(const std::string& op_type) {
-  return Operator("Custom")
-           .CreateSymbol();
-}
-
-/*!
- * \breif Apply deconvolution to input then add a bias.
- * \param data Input data to the DeconvolutionOp.
- * \param weight Weight matrix.
- * \param bias Bias parameter.
- * \param kernel deconvolution kernel size: (y, x)
- * \param num_filter deconvolution filter(channel) number
- * \param stride deconvolution stride: (y, x)
- * \param pad pad for deconvolution: (y, x), a good number is : (kernel-1)/2,
- *        if target_shape set, pad will be ignored and will be computed
- * \param adj adjustment for output shape: (y, x), if target_shape set, adj
- * \param target_shape output shape with targe shape : (y, x)
- * \param num_group number of groups partition
- * \param workspace Tmp workspace for deconvolution (MB)
- * \param no_bias Whether to disable bias parameter.
- * \return new symbol
- */
-inline Symbol Deconvolution(Symbol data,
-                            Symbol weight,
-                            Symbol bias,
-                            Shape kernel,
-                            int num_filter,
-                            Shape stride = Shape(1,1),
-                            Shape pad = Shape(0,0),
-                            Shape adj = Shape(0,0),
-                            Shape target_shape = Shape(0,0),
-                            int num_group = 1,
-                            int64_t workspace = 512,
-                            bool no_bias = true) {
-  return Operator("Deconvolution")
-           .SetParam("kernel", kernel)
-           .SetParam("num_filter", num_filter)
-           .SetParam("stride", stride)
-           .SetParam("pad", pad)
-           .SetParam("adj", adj)
-           .SetParam("target_shape", target_shape)
-           .SetParam("num_group", num_group)
-           .SetParam("workspace", workspace)
-           .SetParam("no_bias", no_bias)
-           .SetInput("data", data)
-           .SetInput("weight", weight)
-           .SetInput("bias", bias)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Apply dropout to input.
- *        During training, each element of the input is randomly set to zero
- *        And then the whole tensor is rescaled by 1/(1-p) to keep the
- *        before applying dropout. During the test time, this behaves as an
- *
- * \param data Input data to dropout.
- * \param p Fraction of the input that gets dropped out at training time
- * \return new symbol
- */
-inline Symbol Dropout(Symbol data,
-                      mx_float p = 0.5) {
-  return Operator("Dropout")
-           .SetParam("p", p)
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Apply matrix multiplication to input then add a bias.
- *        It maps the input of shape `(batch_size, input_dim)` to the shape of
- *        `(batch_size, num_hidden)`. Learnable parameters include the weights
- *        of the linear transform and an optional bias vector.
- * \param data Input data to the FullyConnectedOp.
- * \param weight Weight matrix.
- * \param bias Bias parameter.
- * \param num_hidden Number of hidden nodes of the output.
- * \param no_bias Whether to disable bias parameter.
- * \return new symbol
- */
-inline Symbol FullyConnected(Symbol data,
-                             Symbol weight,
-                             Symbol bias,
-                             int num_hidden,
-                             bool no_bias = false) {
-  return Operator("FullyConnected")
-           .SetParam("num_hidden", num_hidden)
-           .SetParam("no_bias", no_bias)
-           .SetInput("data", data)
-           .SetInput("weight", weight)
-           .SetInput("bias", bias)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Apply a sparse regularization to the output a sigmoid activation
- * \param data Input data.
- * \param sparseness_target The sparseness target
- * \param penalty The tradeoff parameter for the sparseness penalty
- * \param momentum The momentum for running average
- * \return new symbol
- */
-inline Symbol IdentityAttachKLSparseReg(Symbol data,
-                                        mx_float sparseness_target = 0.1,
-                                        mx_float penalty = 0.001,
-                                        mx_float momentum = 0.9) {
-  return Operator("IdentityAttachKLSparseReg")
-           .SetParam("sparseness_target", sparseness_target)
-           .SetParam("penalty", penalty)
-           .SetParam("momentum", momentum)
-           .SetInput("data", data)
+           .SetInput("label", label)
            .CreateSymbol();
 }
 
@@ -4260,226 +3932,23 @@ inline Symbol InstanceNorm(Symbol data,
 }
 
 /*!
- * \breif Set the l2 norm of each instance to a constant.
- * \param data Input data to the L2NormalizationOp.
- * \param eps Epsilon to prevent div 0
- * \param mode Normalization Mode. If set to instance, this operator will
- *        compute a norm for each instance in the batch; this is the default
- *        mode. If set to channel, this operator will compute a cross channel
- *        norm at each position of each instance. If set to spatial, this
+ * \breif Support Vector Machine based transformation on input, backprop L2-SVM
+ * \param data Input data to svm.
+ * \param label Label data.
+ * \param margin Scale the DType(param_.margin) for activation size
+ * \param regularization_coefficient Scale the coefficient responsible for
+ * \param use_linear If set true, uses L1-SVM objective function. Default uses
  * \return new symbol
  */
-inline Symbol L2Normalization(Symbol data,
-                              mx_float eps = 1e-10,
-                              L2NormalizationMode mode = L2NormalizationMode::instance) {
-  static const char *L2NormalizationModeValues[] = {
-    "channel",
-    "instance",
-    "spatial"
-  };
-  return Operator("L2Normalization")
-           .SetParam("eps", eps)
-           .SetParam("mode", L2NormalizationModeValues[int(mode)])
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Apply activation function to input.
- * \param data Input data to activation function.
- * \param act_type Activation function to be applied.
- * \param slope Init slope for the activation. (For leaky and elu only)
- * \param lower_bound Lower bound of random slope. (For rrelu only)
- * \param upper_bound Upper bound of random slope. (For rrelu only)
- * \return new symbol
- */
-inline Symbol LeakyReLU(Symbol data,
-                        LeakyReLUActType act_type = LeakyReLUActType::leaky,
-                        mx_float slope = 0.25,
-                        mx_float lower_bound = 0.125,
-                        mx_float upper_bound = 0.334) {
-  static const char *LeakyReLUActTypeValues[] = {
-    "elu",
-    "leaky",
-    "prelu",
-    "rrelu"
-  };
-  return Operator("LeakyReLU")
-           .SetParam("act_type", LeakyReLUActTypeValues[int(act_type)])
-           .SetParam("slope", slope)
-           .SetParam("lower_bound", lower_bound)
-           .SetParam("upper_bound", upper_bound)
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Apply convolution to input then add a bias.
- * \param data Input data to the ConvolutionOp.
- * \param nsize normalization window width in elements.
- * \param alpha value of the alpha variance scaling parameter in the
- * \param beta value of the beta power parameter in the normalization formula
- * \param knorm value of the k parameter in normalization formula
- * \return new symbol
- */
-inline Symbol LRN(Symbol data,
-                  int nsize,
-                  mx_float alpha = 0.0001,
-                  mx_float beta = 0.75,
-                  mx_float knorm = 2) {
-  return Operator("LRN")
-           .SetParam("nsize", nsize)
-           .SetParam("alpha", alpha)
-           .SetParam("beta", beta)
-           .SetParam("knorm", knorm)
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Get output from a symbol and pass 1 gradient back. This is used as a
- *        terminal loss if unary and binary operator are used to composite a
- * \param data Input data.
- * \param grad_scale gradient scale as a supplement to unary and binary
- * \param valid_thresh regard element valid when x > valid_thresh, this is used
- * \param normalization If set to null, op will not normalize on output
- *        gradient.If set to batch, op will normalize gradient by divide batch
- *        size.If set to valid, op will normalize gradient by divide # sample
- * \return new symbol
- */
-inline Symbol MakeLoss(Symbol data,
-                       mx_float grad_scale = 1,
-                       mx_float valid_thresh = 0,
-                       MakeLossNormalization normalization = MakeLossNormalization::null) {
-  static const char *MakeLossNormalizationValues[] = {
-    "batch",
-    "null",
-    "valid"
-  };
-  return Operator("MakeLoss")
-           .SetParam("grad_scale", grad_scale)
-           .SetParam("valid_thresh", valid_thresh)
-           .SetParam("normalization", MakeLossNormalizationValues[int(normalization)])
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Pads an n-dimensional input tensor. Allows for precise control of the
- *        padding type and how much padding to apply on both sides of a given
- * \param data An n-dimensional input tensor.
- * \param mode Padding type to use. "constant" pads all values with a constant
- *        value, the value of which can be specified with the constant_value
- * \param pad_width A tuple of padding widths of length 2*r, where r is the
- *        rank of the input tensor, specifying number of values padded to the
- *        edges of each axis. (before_1, after_1, ... , before_N, after_N)
- *        unique pad widths for each axis. Equivalent to pad_width in
- * \param constant_value This option is only used when mode is "constant". This
- *        value will be used as the padding value. Defaults to 0 if not
- * \return new symbol
- */
-inline Symbol Pad(Symbol data,
-                  PadMode mode,
-                  Shape pad_width,
-                  double constant_value = 0) {
-  static const char *PadModeValues[] = {
-    "constant",
-    "edge"
-  };
-  return Operator("Pad")
-           .SetParam("mode", PadModeValues[int(mode)])
-           .SetParam("pad_width", pad_width)
-           .SetParam("constant_value", constant_value)
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Perform spatial pooling on inputs.
- * \param data Input data to the pooling operator.
- * \param kernel pooling kernel size: (y, x) or (d, y, x)
- * \param pool_type Pooling type to be applied.
- * \param global_pool Ignore kernel size, do global pooling based on current
- * \param pooling_convention Pooling convention to be applied.kValid is default
- *        setting of Mxnet and rounds down the output pooling size.kFull is
- * \param stride stride: for pooling (y, x) or (d, y, x)
- * \param pad pad for pooling: (y, x) or (d, y, x)
- * \return new symbol
- */
-inline Symbol Pooling(Symbol data,
-                      Shape kernel,
-                      PoolingPoolType pool_type,
-                      bool global_pool = false,
-                      PoolingPoolingConvention pooling_convention = PoolingPoolingConvention::valid,
-                      Shape stride = Shape(1,1),
-                      Shape pad = Shape(0,0)) {
-  static const char *PoolingPoolTypeValues[] = {
-    "avg",
-    "max",
-    "sum"
-  };
-  static const char *PoolingPoolingConventionValues[] = {
-    "full",
-    "valid"
-  };
-  return Operator("Pooling")
-           .SetParam("kernel", kernel)
-           .SetParam("pool_type", PoolingPoolTypeValues[int(pool_type)])
-           .SetParam("global_pool", global_pool)
-           .SetParam("pooling_convention", PoolingPoolingConventionValues[int(pooling_convention)])
-           .SetParam("stride", stride)
-           .SetParam("pad", pad)
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Use linear regression for final output, this is used on final output
- * \param data Input data to function.
- * \param label Input label to function.
- * \param grad_scale Scale the gradient by a float factor
- * \return new symbol
- */
-inline Symbol LinearRegressionOutput(Symbol data,
-                                     Symbol label,
-                                     mx_float grad_scale = 1) {
-  return Operator("LinearRegressionOutput")
-           .SetParam("grad_scale", grad_scale)
-           .SetInput("data", data)
-           .SetInput("label", label)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Use mean absolute error regression for final output, this is used on
- * \param data Input data to function.
- * \param label Input label to function.
- * \param grad_scale Scale the gradient by a float factor
- * \return new symbol
- */
-inline Symbol MAERegressionOutput(Symbol data,
-                                  Symbol label,
-                                  mx_float grad_scale = 1) {
-  return Operator("MAERegressionOutput")
-           .SetParam("grad_scale", grad_scale)
-           .SetInput("data", data)
-           .SetInput("label", label)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Use Logistic regression for final output, this is used on final
- *        Logistic regression is suitable for binary classification or
- * \param data Input data to function.
- * \param label Input label to function.
- * \param grad_scale Scale the gradient by a float factor
- * \return new symbol
- */
-inline Symbol LogisticRegressionOutput(Symbol data,
-                                       Symbol label,
-                                       mx_float grad_scale = 1) {
-  return Operator("LogisticRegressionOutput")
-           .SetParam("grad_scale", grad_scale)
+inline Symbol SVMOutput(Symbol data,
+                        Symbol label,
+                        mx_float margin = 1,
+                        mx_float regularization_coefficient = 1,
+                        bool use_linear = false) {
+  return Operator("SVMOutput")
+           .SetParam("margin", margin)
+           .SetParam("regularization_coefficient", regularization_coefficient)
+           .SetParam("use_linear", use_linear)
            .SetInput("data", data)
            .SetInput("label", label)
            .CreateSymbol();
@@ -4530,78 +3999,50 @@ inline Symbol RNN(Symbol data,
 }
 
 /*!
- * \breif Performs region-of-interest pooling on inputs. Resize bounding box
- *        coordinates by spatial_scale and crop input feature maps
- *        accordingly. The cropped feature maps are pooled by max pooling to a
- *        fixed size output indicated by pooled_size. batch_size will change
- * \param data Input data to the pooling operator, a 4D Feature maps
- * \param rois Bounding box coordinates, a 2D array of [[batch_index, x1, y1,
- *        x2, y2]]. (x1, y1) and (x2, y2) are top left and down right corners
- *        of designated region of interest. batch_index indicates the index of
- * \param pooled_size fix pooled size: (h, w)
- * \param spatial_scale Ratio of input feature map height (or w) to raw image
- *        height (or w). Equals the reciprocal of total stride in
+ * \breif Cast array to a different data type.
+ * \param data Input data to cast function.
+ * \param dtype Target data type.
  * \return new symbol
  */
-inline Symbol ROIPooling(Symbol data,
-                         Symbol rois,
-                         Shape pooled_size,
-                         mx_float spatial_scale) {
-  return Operator("ROIPooling")
-           .SetParam("pooled_size", pooled_size)
-           .SetParam("spatial_scale", spatial_scale)
+inline Symbol Cast(Symbol data,
+                   CastDtype dtype) {
+  static const char *CastDtypeValues[] = {
+    "float16",
+    "float32",
+    "float64",
+    "int32",
+    "uint8"
+  };
+  return Operator("Cast")
+           .SetParam("dtype", CastDtypeValues[int(dtype)])
            .SetInput("data", data)
-           .SetInput("rois", rois)
            .CreateSymbol();
 }
 
 /*!
- * \breif Takes the last element of a sequence. Takes an n-dimensional tensor
- *        of the form [max sequence length, batchsize, other dims] and returns
- *        a (n-1)-dimensional tensor of the form [batchsize, other dims]. This
- *        operator takes an optional input tensor sequence_length of positive
- *        ints of dimension [batchsize] when the sequence_length option is set
- *        to true. This allows the operator to handle variable-length
- *        sequences. If sequence_length is false, then each example in the
- * \param data n-dimensional input tensor of the form [max sequence length,
- * \param sequence_length vector of sequence lengths of size batchsize
- * \param use_sequence_length If set to true, this layer takes in extra input
+ * \breif Crop the 2nd and 3rd dim of input data, with the corresponding size
+ *        of h_w or with width and height of the second input symbol, i.e.,
+ *        with one input, we need h_w to specify the crop height and width,
+ * \param data Tensor or List of Tensors, the second input will be used as
+ * \param num_args Number of inputs for crop, if equals one, then we will use
+ *        the h_wfor crop height and width, else if equals two, then we will
+ *        use the heightand width of the second input symbol, we name
+ * \param offset crop offset coordinate: (y, x)
+ * \param h_w crop height and weight: (h, w)
+ * \param center_crop If set to true, then it will use be the center_crop,or it
  * \return new symbol
  */
-inline Symbol SequenceLast(Symbol data,
-                           Symbol sequence_length,
-                           bool use_sequence_length = false) {
-  return Operator("SequenceLast")
-           .SetParam("use_sequence_length", use_sequence_length)
+inline Symbol Crop(Symbol data,
+                   int num_args,
+                   Shape offset = Shape(0,0),
+                   Shape h_w = Shape(0,0),
+                   bool center_crop = false) {
+  return Operator("Crop")
+           .SetParam("num_args", num_args)
+           .SetParam("offset", offset)
+           .SetParam("h_w", h_w)
+           .SetParam("center_crop", center_crop)
            .SetInput("data", data)
-           .SetInput("sequence_length", sequence_length)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Sets all elements outside the sequence to a constant value. Takes an
- *        n-dimensional tensor of the form [max sequence length, batchsize,
- *        other dims] and returns a tensor of the same shape. This operator
- *        takes an optional input tensor sequence_length of positive ints of
- *        dimension [batchsize] when the sequence_length option is set to
- *        true. This allows the operator to handle variable-length sequences.
- *        If sequence_length is false, then each example in the batch is
- *        assumed to have the max sequence length, and this operator becomes
- * \param data n-dimensional input tensor of the form [max sequence length,
- * \param sequence_length vector of sequence lengths of size batchsize
- * \param use_sequence_length If set to true, this layer takes in extra input
- * \param value The value to be used as a mask.
- * \return new symbol
- */
-inline Symbol SequenceMask(Symbol data,
-                           Symbol sequence_length,
-                           bool use_sequence_length = false,
-                           mx_float value = 0) {
-  return Operator("SequenceMask")
-           .SetParam("use_sequence_length", use_sequence_length)
-           .SetParam("value", value)
-           .SetInput("data", data)
-           .SetInput("sequence_length", sequence_length)
            .CreateSymbol();
 }
 
@@ -4629,44 +4070,79 @@ inline Symbol SequenceReverse(Symbol data,
 }
 
 /*!
- * \breif Slice input equally along specified axis
- * \param num_outputs Number of outputs to be sliced.
- * \param axis Dimension along which to slice.
- * \param squeeze_axis If true AND the sliced dimension becomes 1, squeeze that
+ * \breif Apply spatial transformer to input feature map.
+ * \param data Input data to the SpatialTransformerOp.
+ * \param loc localisation net, the output dim should be 6 when transform_type
+ *        is affine, and the name of loc symbol should better starts with
+ *        'stn_loc', so that initialization it with iddentify tranform, or you
+ * \param transform_type transformation type
+ * \param sampler_type sampling type
+ * \param target_shape output shape(h, w) of spatial transformer: (y, x)
  * \return new symbol
  */
-inline Symbol SliceChannel(int num_outputs,
-                           int axis = 1,
-                           bool squeeze_axis = false) {
-  return Operator("SliceChannel")
-           .SetParam("num_outputs", num_outputs)
-           .SetParam("axis", axis)
-           .SetParam("squeeze_axis", squeeze_axis)
+inline Symbol SpatialTransformer(Symbol data,
+                                 Symbol loc,
+                                 SpatialTransformerTransformType transform_type,
+                                 SpatialTransformerSamplerType sampler_type,
+                                 Shape target_shape = Shape(0,0)) {
+  static const char *SpatialTransformerTransformTypeValues[] = {
+    "affine"
+  };
+  static const char *SpatialTransformerSamplerTypeValues[] = {
+    "bilinear"
+  };
+  return Operator("SpatialTransformer")
+           .SetParam("transform_type", SpatialTransformerTransformTypeValues[int(transform_type)])
+           .SetParam("sampler_type", SpatialTransformerSamplerTypeValues[int(sampler_type)])
+           .SetParam("target_shape", target_shape)
+           .SetInput("data", data)
+           .SetInput("loc", loc)
            .CreateSymbol();
 }
 
 /*!
- * \breif Apply softmax activation to input. This is intended for internal
- *        layers. For output (loss layer) please use SoftmaxOutput. If
- *        mode=instance, this operator will compute a softmax for each
- *        instance in the batch; this is the default mode. If mode=channel,
- *        this operator will compute a num_channel-class softmax at each
- *        position of each instance; this can be used for fully convolutional
- * \param data Input data to activation function.
- * \param mode Softmax Mode. If set to instance, this operator will compute a
- *        softmax for each instance in the batch; this is the default mode. If
- *        set to channel, this operator will compute a num_channel-class
- *        softmax at each position of each instance; this can be used for
+ * \breif Apply swapaxis to input.
+ * \param data Input data to the SwapAxisOp.
+ * \param dim1 the first axis to be swapped.
+ * \param dim2 the second axis to be swapped.
  * \return new symbol
  */
-inline Symbol SoftmaxActivation(Symbol data,
-                                SoftmaxActivationMode mode = SoftmaxActivationMode::instance) {
-  static const char *SoftmaxActivationModeValues[] = {
-    "channel",
-    "instance"
+inline Symbol SwapAxis(Symbol data,
+                       int dim1 = 0,
+                       int dim2 = 0) {
+  return Operator("SwapAxis")
+           .SetParam("dim1", dim1)
+           .SetParam("dim2", dim2)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Pads an n-dimensional input tensor. Allows for precise control of the
+ *        padding type and how much padding to apply on both sides of a given
+ * \param data An n-dimensional input tensor.
+ * \param mode Padding type to use. "constant" pads all values with a constant
+ *        value, the value of which can be specified with the constant_value
+ * \param pad_width A tuple of padding widths of length 2*r, where r is the
+ *        rank of the input tensor, specifying number of values padded to the
+ *        edges of each axis. (before_1, after_1, ... , before_N, after_N)
+ *        unique pad widths for each axis. Equivalent to pad_width in
+ * \param constant_value This option is only used when mode is "constant". This
+ *        value will be used as the padding value. Defaults to 0 if not
+ * \return new symbol
+ */
+inline Symbol Pad(Symbol data,
+                  PadMode mode,
+                  Shape pad_width,
+                  double constant_value = 0) {
+  static const char *PadModeValues[] = {
+    "constant",
+    "edge"
   };
-  return Operator("SoftmaxActivation")
-           .SetParam("mode", SoftmaxActivationModeValues[int(mode)])
+  return Operator("Pad")
+           .SetParam("mode", PadModeValues[int(mode)])
+           .SetParam("pad_width", pad_width)
+           .SetParam("constant_value", constant_value)
            .SetInput("data", data)
            .CreateSymbol();
 }
@@ -4757,72 +4233,191 @@ inline Symbol Softmax(Symbol data,
 }
 
 /*!
- * \breif Apply spatial transformer to input feature map.
- * \param data Input data to the SpatialTransformerOp.
- * \param loc localisation net, the output dim should be 6 when transform_type
- *        is affine, and the name of loc symbol should better starts with
- *        'stn_loc', so that initialization it with iddentify tranform, or you
- * \param transform_type transformation type
- * \param sampler_type sampling type
- * \param target_shape output shape(h, w) of spatial transformer: (y, x)
+ * \breif Apply activation function to input.
+ * \param data Input data to activation function.
+ * \param act_type Activation function to be applied.
+ * \param slope Init slope for the activation. (For leaky and elu only)
+ * \param lower_bound Lower bound of random slope. (For rrelu only)
+ * \param upper_bound Upper bound of random slope. (For rrelu only)
  * \return new symbol
  */
-inline Symbol SpatialTransformer(Symbol data,
-                                 Symbol loc,
-                                 SpatialTransformerTransformType transform_type,
-                                 SpatialTransformerSamplerType sampler_type,
-                                 Shape target_shape = Shape(0,0)) {
-  static const char *SpatialTransformerTransformTypeValues[] = {
-    "affine"
+inline Symbol LeakyReLU(Symbol data,
+                        LeakyReLUActType act_type = LeakyReLUActType::leaky,
+                        mx_float slope = 0.25,
+                        mx_float lower_bound = 0.125,
+                        mx_float upper_bound = 0.334) {
+  static const char *LeakyReLUActTypeValues[] = {
+    "elu",
+    "leaky",
+    "prelu",
+    "rrelu"
   };
-  static const char *SpatialTransformerSamplerTypeValues[] = {
-    "bilinear"
-  };
-  return Operator("SpatialTransformer")
-           .SetParam("transform_type", SpatialTransformerTransformTypeValues[int(transform_type)])
-           .SetParam("sampler_type", SpatialTransformerSamplerTypeValues[int(sampler_type)])
-           .SetParam("target_shape", target_shape)
+  return Operator("LeakyReLU")
+           .SetParam("act_type", LeakyReLUActTypeValues[int(act_type)])
+           .SetParam("slope", slope)
+           .SetParam("lower_bound", lower_bound)
+           .SetParam("upper_bound", upper_bound)
            .SetInput("data", data)
-           .SetInput("loc", loc)
            .CreateSymbol();
 }
 
 /*!
- * \breif Support Vector Machine based transformation on input, backprop L2-SVM
- * \param data Input data to svm.
- * \param label Label data.
- * \param margin Scale the DType(param_.margin) for activation size
- * \param regularization_coefficient Scale the coefficient responsible for
- * \param use_linear If set true, uses L1-SVM objective function. Default uses
+ * \breif Takes the last element of a sequence. Takes an n-dimensional tensor
+ *        of the form [max sequence length, batchsize, other dims] and returns
+ *        a (n-1)-dimensional tensor of the form [batchsize, other dims]. This
+ *        operator takes an optional input tensor sequence_length of positive
+ *        ints of dimension [batchsize] when the sequence_length option is set
+ *        to true. This allows the operator to handle variable-length
+ *        sequences. If sequence_length is false, then each example in the
+ * \param data n-dimensional input tensor of the form [max sequence length,
+ * \param sequence_length vector of sequence lengths of size batchsize
+ * \param use_sequence_length If set to true, this layer takes in extra input
  * \return new symbol
  */
-inline Symbol SVMOutput(Symbol data,
-                        Symbol label,
-                        mx_float margin = 1,
-                        mx_float regularization_coefficient = 1,
-                        bool use_linear = false) {
-  return Operator("SVMOutput")
-           .SetParam("margin", margin)
-           .SetParam("regularization_coefficient", regularization_coefficient)
-           .SetParam("use_linear", use_linear)
+inline Symbol SequenceLast(Symbol data,
+                           Symbol sequence_length,
+                           bool use_sequence_length = false) {
+  return Operator("SequenceLast")
+           .SetParam("use_sequence_length", use_sequence_length)
            .SetInput("data", data)
-           .SetInput("label", label)
+           .SetInput("sequence_length", sequence_length)
            .CreateSymbol();
 }
 
 /*!
- * \breif Apply swapaxis to input.
- * \param data Input data to the SwapAxisOp.
- * \param dim1 the first axis to be swapped.
- * \param dim2 the second axis to be swapped.
+ * \breif Set the l2 norm of each instance to a constant.
+ * \param data Input data to the L2NormalizationOp.
+ * \param eps Epsilon to prevent div 0
+ * \param mode Normalization Mode. If set to instance, this operator will
+ *        compute a norm for each instance in the batch; this is the default
+ *        mode. If set to channel, this operator will compute a cross channel
+ *        norm at each position of each instance. If set to spatial, this
  * \return new symbol
  */
-inline Symbol SwapAxis(Symbol data,
-                       int dim1 = 0,
-                       int dim2 = 0) {
-  return Operator("SwapAxis")
-           .SetParam("dim1", dim1)
-           .SetParam("dim2", dim2)
+inline Symbol L2Normalization(Symbol data,
+                              mx_float eps = 1e-10,
+                              L2NormalizationMode mode = L2NormalizationMode::instance) {
+  static const char *L2NormalizationModeValues[] = {
+    "channel",
+    "instance",
+    "spatial"
+  };
+  return Operator("L2Normalization")
+           .SetParam("eps", eps)
+           .SetParam("mode", L2NormalizationModeValues[int(mode)])
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Apply convolution to input then add a bias.
+ * \param data Input data to the ConvolutionOp.
+ * \param nsize normalization window width in elements.
+ * \param alpha value of the alpha variance scaling parameter in the
+ * \param beta value of the beta power parameter in the normalization formula
+ * \param knorm value of the k parameter in normalization formula
+ * \return new symbol
+ */
+inline Symbol LRN(Symbol data,
+                  int nsize,
+                  mx_float alpha = 0.0001,
+                  mx_float beta = 0.75,
+                  mx_float knorm = 2) {
+  return Operator("LRN")
+           .SetParam("nsize", nsize)
+           .SetParam("alpha", alpha)
+           .SetParam("beta", beta)
+           .SetParam("knorm", knorm)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Apply correlation to inputs
+ * \param data1 Input data1 to the correlation.
+ * \param data2 Input data2 to the correlation.
+ * \param kernel_size kernel size for Correlation must be an odd number
+ * \param max_displacement Max displacement of Correlation
+ * \param stride1 stride1 quantize data1 globally
+ * \param stride2 stride2 quantize data2 within the neighborhood centered
+ * \param pad_size pad for Correlation
+ * \param is_multiply operation type is either multiplication or subduction
+ * \return new symbol
+ */
+inline Symbol Correlation(Symbol data1,
+                          Symbol data2,
+                          int kernel_size = 1,
+                          int max_displacement = 1,
+                          int stride1 = 1,
+                          int stride2 = 1,
+                          int pad_size = 0,
+                          bool is_multiply = true) {
+  return Operator("Correlation")
+           .SetParam("kernel_size", kernel_size)
+           .SetParam("max_displacement", max_displacement)
+           .SetParam("stride1", stride1)
+           .SetParam("stride2", stride2)
+           .SetParam("pad_size", pad_size)
+           .SetParam("is_multiply", is_multiply)
+           .SetInput("data1", data1)
+           .SetInput("data2", data2)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Sets all elements outside the sequence to a constant value. Takes an
+ *        n-dimensional tensor of the form [max sequence length, batchsize,
+ *        other dims] and returns a tensor of the same shape. This operator
+ *        takes an optional input tensor sequence_length of positive ints of
+ *        dimension [batchsize] when the sequence_length option is set to
+ *        true. This allows the operator to handle variable-length sequences.
+ *        If sequence_length is false, then each example in the batch is
+ *        assumed to have the max sequence length, and this operator becomes
+ * \param data n-dimensional input tensor of the form [max sequence length,
+ * \param sequence_length vector of sequence lengths of size batchsize
+ * \param use_sequence_length If set to true, this layer takes in extra input
+ * \param value The value to be used as a mask.
+ * \return new symbol
+ */
+inline Symbol SequenceMask(Symbol data,
+                           Symbol sequence_length,
+                           bool use_sequence_length = false,
+                           mx_float value = 0) {
+  return Operator("SequenceMask")
+           .SetParam("use_sequence_length", use_sequence_length)
+           .SetParam("value", value)
+           .SetInput("data", data)
+           .SetInput("sequence_length", sequence_length)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Get output from a symbol and pass 0 gradient back
+ * \param data Input data.
+ * \return new symbol
+ */
+inline Symbol BlockGrad(Symbol data) {
+  return Operator("BlockGrad")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Apply a sparse regularization to the output a sigmoid activation
+ * \param data Input data.
+ * \param sparseness_target The sparseness target
+ * \param penalty The tradeoff parameter for the sparseness penalty
+ * \param momentum The momentum for running average
+ * \return new symbol
+ */
+inline Symbol IdentityAttachKLSparseReg(Symbol data,
+                                        mx_float sparseness_target = 0.1,
+                                        mx_float penalty = 0.001,
+                                        mx_float momentum = 0.9) {
+  return Operator("IdentityAttachKLSparseReg")
+           .SetParam("sparseness_target", sparseness_target)
+           .SetParam("penalty", penalty)
+           .SetParam("momentum", momentum)
            .SetInput("data", data)
            .CreateSymbol();
 }
@@ -4866,6 +4461,461 @@ inline Symbol UpSampling(const std::vector<Symbol>& data,
            .SetParam("multi_input_mode", UpSamplingMultiInputModeValues[int(multi_input_mode)])
            .SetParam("workspace", workspace)
 (data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Apply deconvolution to input then add a bias.
+ * \param data Input data to the DeconvolutionOp.
+ * \param weight Weight matrix.
+ * \param bias Bias parameter.
+ * \param kernel deconvolution kernel size: (y, x)
+ * \param num_filter deconvolution filter(channel) number
+ * \param stride deconvolution stride: (y, x)
+ * \param pad pad for deconvolution: (y, x), a good number is : (kernel-1)/2,
+ *        if target_shape set, pad will be ignored and will be computed
+ * \param adj adjustment for output shape: (y, x), if target_shape set, adj
+ * \param target_shape output shape with targe shape : (y, x)
+ * \param num_group number of groups partition
+ * \param workspace Tmp workspace for deconvolution (MB)
+ * \param no_bias Whether to disable bias parameter.
+ * \return new symbol
+ */
+inline Symbol Deconvolution(Symbol data,
+                            Symbol weight,
+                            Symbol bias,
+                            Shape kernel,
+                            int num_filter,
+                            Shape stride = Shape(1,1),
+                            Shape pad = Shape(0,0),
+                            Shape adj = Shape(0,0),
+                            Shape target_shape = Shape(0,0),
+                            int num_group = 1,
+                            int64_t workspace = 512,
+                            bool no_bias = true) {
+  return Operator("Deconvolution")
+           .SetParam("kernel", kernel)
+           .SetParam("num_filter", num_filter)
+           .SetParam("stride", stride)
+           .SetParam("pad", pad)
+           .SetParam("adj", adj)
+           .SetParam("target_shape", target_shape)
+           .SetParam("num_group", num_group)
+           .SetParam("workspace", workspace)
+           .SetParam("no_bias", no_bias)
+           .SetInput("data", data)
+           .SetInput("weight", weight)
+           .SetInput("bias", bias)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Apply convolution to input then add a bias.
+ * \param data Input data to the ConvolutionOp.
+ * \param weight Weight matrix.
+ * \param bias Bias parameter.
+ * \param kernel convolution kernel size: (h, w) or (d, h, w)
+ * \param num_filter convolution filter(channel) number
+ * \param stride convolution stride: (h, w) or (d, h, w)
+ * \param dilate convolution dilate: (h, w) or (d, h, w)
+ * \param pad pad for convolution: (h, w) or (d, h, w)
+ * \param num_group Number of group partitions. Equivalent to slicing input
+ *        partitions, apply convolution on each, then concatenate the results
+ * \param workspace Maximum tmp workspace allowed for convolution (MB).
+ * \param no_bias Whether to disable bias parameter.
+ * \param cudnn_tune Whether to pick convolution algo by running performance
+ *        Leads to higher startup time but may give faster speed. Options are:
+ *        'off': no tuning
+ *        'limited_workspace': run test and pick the fastest algorithm that
+ *        'fastest': pick the fastest algorithm and ignore workspace limit.
+ *        If set to None (default), behavior is determined by environment
+ *        variable MXNET_CUDNN_AUTOTUNE_DEFAULT: 0 for off,
+ *        1 for limited workspace (default), 2 for fastest.
+ * \param cudnn_off Turn off cudnn for this layer.
+ * \param layout Set layout for input, output and weight. Empty for
+ *        default layout: NCHW for 2d and NCDHW for 3d.
+ * \return new symbol
+ */
+inline Symbol Convolution(Symbol data,
+                          Symbol weight,
+                          Symbol bias,
+                          Shape kernel,
+                          int num_filter,
+                          Shape stride = Shape(),
+                          Shape dilate = Shape(),
+                          Shape pad = Shape(),
+                          int num_group = 1,
+                          int64_t workspace = 1024,
+                          bool no_bias = false,
+                          ConvolutionCudnnTune cudnn_tune = ConvolutionCudnnTune::None,
+                          bool cudnn_off = false,
+                          ConvolutionLayout layout = ConvolutionLayout::None) {
+  static const char *ConvolutionCudnnTuneValues[] = {
+    "None",
+    "fastest",
+    "limited_workspace",
+    "off"
+  };
+  static const char *ConvolutionLayoutValues[] = {
+    "None",
+    "NCDHW",
+    "NCHW",
+    "NDHWC",
+    "NHWC"
+  };
+  return Operator("Convolution")
+           .SetParam("kernel", kernel)
+           .SetParam("num_filter", num_filter)
+           .SetParam("stride", stride)
+           .SetParam("dilate", dilate)
+           .SetParam("pad", pad)
+           .SetParam("num_group", num_group)
+           .SetParam("workspace", workspace)
+           .SetParam("no_bias", no_bias)
+           .SetParam("cudnn_tune", ConvolutionCudnnTuneValues[int(cudnn_tune)])
+           .SetParam("cudnn_off", cudnn_off)
+           .SetParam("layout", ConvolutionLayoutValues[int(layout)])
+           .SetInput("data", data)
+           .SetInput("weight", weight)
+           .SetInput("bias", bias)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Performs region-of-interest pooling on inputs. Resize bounding box
+ *        coordinates by spatial_scale and crop input feature maps
+ *        accordingly. The cropped feature maps are pooled by max pooling to a
+ *        fixed size output indicated by pooled_size. batch_size will change
+ * \param data Input data to the pooling operator, a 4D Feature maps
+ * \param rois Bounding box coordinates, a 2D array of [[batch_index, x1, y1,
+ *        x2, y2]]. (x1, y1) and (x2, y2) are top left and down right corners
+ *        of designated region of interest. batch_index indicates the index of
+ * \param pooled_size fix pooled size: (h, w)
+ * \param spatial_scale Ratio of input feature map height (or w) to raw image
+ *        height (or w). Equals the reciprocal of total stride in
+ * \return new symbol
+ */
+inline Symbol ROIPooling(Symbol data,
+                         Symbol rois,
+                         Shape pooled_size,
+                         mx_float spatial_scale) {
+  return Operator("ROIPooling")
+           .SetParam("pooled_size", pooled_size)
+           .SetParam("spatial_scale", spatial_scale)
+           .SetInput("data", data)
+           .SetInput("rois", rois)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Apply batch normalization to input.
+ * \param data Input data to batch normalization
+ * \param eps Epsilon to prevent div 0
+ * \param momentum Momentum for moving average
+ * \param fix_gamma Fix gamma while training
+ * \param use_global_stats Whether use global moving statistics instead of
+ *        local batch-norm. This will force change batch-norm into a scale
+ * \return new symbol
+ */
+inline Symbol CuDNNBatchNorm(Symbol data,
+                             mx_float eps = 0.001,
+                             mx_float momentum = 0.9,
+                             bool fix_gamma = true,
+                             bool use_global_stats = false) {
+  return Operator("CuDNNBatchNorm")
+           .SetParam("eps", eps)
+           .SetParam("momentum", momentum)
+           .SetParam("fix_gamma", fix_gamma)
+           .SetParam("use_global_stats", use_global_stats)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Apply matrix multiplication to input then add a bias.
+ *        It maps the input of shape `(batch_size, input_dim)` to the shape of
+ *        `(batch_size, num_hidden)`. Learnable parameters include the weights
+ *        of the linear transform and an optional bias vector.
+ * \param data Input data to the FullyConnectedOp.
+ * \param weight Weight matrix.
+ * \param bias Bias parameter.
+ * \param num_hidden Number of hidden nodes of the output.
+ * \param no_bias Whether to disable bias parameter.
+ * \return new symbol
+ */
+inline Symbol FullyConnected(Symbol data,
+                             Symbol weight,
+                             Symbol bias,
+                             int num_hidden,
+                             bool no_bias = false) {
+  return Operator("FullyConnected")
+           .SetParam("num_hidden", num_hidden)
+           .SetParam("no_bias", no_bias)
+           .SetInput("data", data)
+           .SetInput("weight", weight)
+           .SetInput("bias", bias)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Use linear regression for final output, this is used on final output
+ * \param data Input data to function.
+ * \param label Input label to function.
+ * \param grad_scale Scale the gradient by a float factor
+ * \return new symbol
+ */
+inline Symbol LinearRegressionOutput(Symbol data,
+                                     Symbol label,
+                                     mx_float grad_scale = 1) {
+  return Operator("LinearRegressionOutput")
+           .SetParam("grad_scale", grad_scale)
+           .SetInput("data", data)
+           .SetInput("label", label)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Use mean absolute error regression for final output, this is used on
+ * \param data Input data to function.
+ * \param label Input label to function.
+ * \param grad_scale Scale the gradient by a float factor
+ * \return new symbol
+ */
+inline Symbol MAERegressionOutput(Symbol data,
+                                  Symbol label,
+                                  mx_float grad_scale = 1) {
+  return Operator("MAERegressionOutput")
+           .SetParam("grad_scale", grad_scale)
+           .SetInput("data", data)
+           .SetInput("label", label)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Use Logistic regression for final output, this is used on final
+ *        Logistic regression is suitable for binary classification or
+ * \param data Input data to function.
+ * \param label Input label to function.
+ * \param grad_scale Scale the gradient by a float factor
+ * \return new symbol
+ */
+inline Symbol LogisticRegressionOutput(Symbol data,
+                                       Symbol label,
+                                       mx_float grad_scale = 1) {
+  return Operator("LogisticRegressionOutput")
+           .SetParam("grad_scale", grad_scale)
+           .SetInput("data", data)
+           .SetInput("label", label)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Get output from a symbol and pass 1 gradient back. This is used as a
+ *        terminal loss if unary and binary operator are used to composite a
+ * \param data Input data.
+ * \param grad_scale gradient scale as a supplement to unary and binary
+ * \param valid_thresh regard element valid when x > valid_thresh, this is used
+ * \param normalization If set to null, op will not normalize on output
+ *        gradient.If set to batch, op will normalize gradient by divide batch
+ *        size.If set to valid, op will normalize gradient by divide # sample
+ * \return new symbol
+ */
+inline Symbol MakeLoss(Symbol data,
+                       mx_float grad_scale = 1,
+                       mx_float valid_thresh = 0,
+                       MakeLossNormalization normalization = MakeLossNormalization::null) {
+  static const char *MakeLossNormalizationValues[] = {
+    "batch",
+    "null",
+    "valid"
+  };
+  return Operator("MakeLoss")
+           .SetParam("grad_scale", grad_scale)
+           .SetParam("valid_thresh", valid_thresh)
+           .SetParam("normalization", MakeLossNormalizationValues[int(normalization)])
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Slice input equally along specified axis
+ * \param num_outputs Number of outputs to be sliced.
+ * \param axis Dimension along which to slice.
+ * \param squeeze_axis If true AND the sliced dimension becomes 1, squeeze that
+ * \return new symbol
+ */
+inline Symbol SliceChannel(int num_outputs,
+                           int axis = 1,
+                           bool squeeze_axis = false) {
+  return Operator("SliceChannel")
+           .SetParam("num_outputs", num_outputs)
+           .SetParam("axis", axis)
+           .SetParam("squeeze_axis", squeeze_axis)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Perform a feature concat on channel dim (defaut is 1) over all
+ * \param data List of tensors to concatenate
+ * \param num_args Number of inputs to be concated.
+ * \param dim the dimension to be concated.
+ * \return new symbol
+ */
+inline Symbol Concat(const std::vector<Symbol>& data,
+                     int num_args,
+                     int dim = 1) {
+  return Operator("Concat")
+           .SetParam("num_args", num_args)
+           .SetParam("dim", dim)
+(data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Elementwise activation function.
+ *
+ *        The following activation types are supported (operations are applied
+ *        scalar of the input tensor):
+ *
+ *        - `relu`: Rectified Linear Unit, `y = max(x, 0)`
+ *        - `sigmoid`: `y = 1 / (1 + exp(-x))`
+ *        - `tanh`: Hyperbolic tangent, `y = (exp(x) - exp(-x)) / (exp(x) +
+ *        - `softrelu`: Soft ReLU, or SoftPlus, `y = log(1 + exp(x))`
+ *
+ *        See `LeakyReLU` for other activations with parameters.
+ *
+ * \param data Input data to activation function.
+ * \param act_type Activation function to be applied.
+ * \return new symbol
+ */
+inline Symbol Activation(Symbol data,
+                         ActivationActType act_type) {
+  static const char *ActivationActTypeValues[] = {
+    "relu",
+    "sigmoid",
+    "softrelu",
+    "tanh"
+  };
+  return Operator("Activation")
+           .SetParam("act_type", ActivationActTypeValues[int(act_type)])
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Custom operator implemented in frontend.
+ * \param op_type Type of custom operator. Must be registered first.
+ * \return new symbol
+ */
+inline Symbol Custom(const std::string& op_type) {
+  return Operator("Custom")
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Perform spatial pooling on inputs.
+ * \param data Input data to the pooling operator.
+ * \param kernel pooling kernel size: (y, x) or (d, y, x)
+ * \param pool_type Pooling type to be applied.
+ * \param global_pool Ignore kernel size, do global pooling based on current
+ * \param pooling_convention Pooling convention to be applied.kValid is default
+ *        setting of Mxnet and rounds down the output pooling size.kFull is
+ * \param stride stride: for pooling (y, x) or (d, y, x)
+ * \param pad pad for pooling: (y, x) or (d, y, x)
+ * \return new symbol
+ */
+inline Symbol Pooling(Symbol data,
+                      Shape kernel,
+                      PoolingPoolType pool_type,
+                      bool global_pool = false,
+                      PoolingPoolingConvention pooling_convention = PoolingPoolingConvention::valid,
+                      Shape stride = Shape(1,1),
+                      Shape pad = Shape(0,0)) {
+  static const char *PoolingPoolTypeValues[] = {
+    "avg",
+    "max",
+    "sum"
+  };
+  static const char *PoolingPoolingConventionValues[] = {
+    "full",
+    "valid"
+  };
+  return Operator("Pooling")
+           .SetParam("kernel", kernel)
+           .SetParam("pool_type", PoolingPoolTypeValues[int(pool_type)])
+           .SetParam("global_pool", global_pool)
+           .SetParam("pooling_convention", PoolingPoolingConventionValues[int(pooling_convention)])
+           .SetParam("stride", stride)
+           .SetParam("pad", pad)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Apply batch normalization to input.
+ * \param data Input data to batch normalization
+ * \param eps Epsilon to prevent div 0
+ * \param momentum Momentum for moving average
+ * \param fix_gamma Fix gamma while training
+ * \param use_global_stats Whether use global moving statistics instead of
+ *        local batch-norm. This will force change batch-norm into a scale
+ * \return new symbol
+ */
+inline Symbol BatchNorm(Symbol data,
+                        mx_float eps = 0.001,
+                        mx_float momentum = 0.9,
+                        bool fix_gamma = true,
+                        bool use_global_stats = false) {
+  return Operator("BatchNorm")
+           .SetParam("eps", eps)
+           .SetParam("momentum", momentum)
+           .SetParam("fix_gamma", fix_gamma)
+           .SetParam("use_global_stats", use_global_stats)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Apply dropout to input.
+ *        During training, each element of the input is randomly set to zero
+ *        And then the whole tensor is rescaled by 1/(1-p) to keep the
+ *        before applying dropout. During the test time, this behaves as an
+ *
+ * \param data Input data to dropout.
+ * \param p Fraction of the input that gets dropped out at training time
+ * \return new symbol
+ */
+inline Symbol Dropout(Symbol data,
+                      mx_float p = 0.5) {
+  return Operator("Dropout")
+           .SetParam("p", p)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Apply softmax activation to input. This is intended for internal
+ *        layers. For output (loss layer) please use SoftmaxOutput. If
+ *        mode=instance, this operator will compute a softmax for each
+ *        instance in the batch; this is the default mode. If mode=channel,
+ *        this operator will compute a num_channel-class softmax at each
+ *        position of each instance; this can be used for fully convolutional
+ * \param data Input data to activation function.
+ * \param mode Softmax Mode. If set to instance, this operator will compute a
+ *        softmax for each instance in the batch; this is the default mode. If
+ *        set to channel, this operator will compute a num_channel-class
+ *        softmax at each position of each instance; this can be used for
+ * \return new symbol
+ */
+inline Symbol SoftmaxActivation(Symbol data,
+                                SoftmaxActivationMode mode = SoftmaxActivationMode::instance) {
+  static const char *SoftmaxActivationModeValues[] = {
+    "channel",
+    "instance"
+  };
+  return Operator("SoftmaxActivation")
+           .SetParam("mode", SoftmaxActivationModeValues[int(mode)])
+           .SetInput("data", data)
            .CreateSymbol();
 }
 

--- a/include/mxnet-cpp/op.h
+++ b/include/mxnet-cpp/op.h
@@ -17,7 +17,1372 @@
 namespace mxnet {
 namespace cpp {
 
-/*! \breif Activation function to be applied. 
+/*!
+ * \breif Compute argmax
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_index.cc:11
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axis Empty or unsigned. The axis to perform the reduction.If left
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol argmax(const std::string& symbol_name,
+                     Symbol data,
+                     int axis = -1,
+                     bool keepdims = false) {
+  return Operator("argmax")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Compute argmin
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_index.cc:15
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axis Empty or unsigned. The axis to perform the reduction.If left
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol argmin(const std::string& symbol_name,
+                     Symbol data,
+                     int axis = -1,
+                     bool keepdims = false) {
+  return Operator("argmin")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param src Source input
+ * \return new symbol
+ */
+inline Symbol argmax_channel(const std::string& symbol_name,
+                             Symbol src) {
+  return Operator("argmax_channel")
+           .SetInput("src", src)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Sum src along axis. If axis is empty, global reduction is performed
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:17
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axis Empty or unsigned or tuple. The axes to perform the reduction.If
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol sum(const std::string& symbol_name,
+                  Symbol data,
+                  Shape axis = Shape(),
+                  bool keepdims = false) {
+  return Operator("sum")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Compute product of src along axis. If axis is empty, global reduction
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:27
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axis Empty or unsigned or tuple. The axes to perform the reduction.If
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol prod(const std::string& symbol_name,
+                   Symbol data,
+                   Shape axis = Shape(),
+                   bool keepdims = false) {
+  return Operator("prod")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Sum src along axis, ignoring NaN values. If axis is empty, global
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:37
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axis Empty or unsigned or tuple. The axes to perform the reduction.If
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol nansum(const std::string& symbol_name,
+                     Symbol data,
+                     Shape axis = Shape(),
+                     bool keepdims = false) {
+  return Operator("nansum")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Compute product of src along axis, ignoring NaN values. If axis is
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:47
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axis Empty or unsigned or tuple. The axes to perform the reduction.If
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol nanprod(const std::string& symbol_name,
+                      Symbol data,
+                      Shape axis = Shape(),
+                      bool keepdims = false) {
+  return Operator("nanprod")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Compute max along axis. If axis is empty, global reduction is
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:57
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axis Empty or unsigned or tuple. The axes to perform the reduction.If
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol max(const std::string& symbol_name,
+                  Symbol data,
+                  Shape axis = Shape(),
+                  bool keepdims = false) {
+  return Operator("max")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Compute min along axis. If axis is empty, global reduction is
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:67
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axis Empty or unsigned or tuple. The axes to perform the reduction.If
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol min(const std::string& symbol_name,
+                  Symbol data,
+                  Shape axis = Shape(),
+                  bool keepdims = false) {
+  return Operator("min")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Broadcast src along axis
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:76
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axis The axes to perform the broadcasting.
+ * \param size Target sizes of the broadcasting axes.
+ * \return new symbol
+ */
+inline Symbol broadcast_axis(const std::string& symbol_name,
+                             Symbol data,
+                             Shape axis = Shape(),
+                             Shape size = Shape()) {
+  return Operator("broadcast_axis")
+           .SetParam("axis", axis)
+           .SetParam("size", size)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Broadcast src to shape
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:83
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param shape The shape of the desired array. We can set the dim to zero if
+ *        it's same as the original. E.g `A = broadcast_to(B, shape=(10, 0,
+ *        0))` has the same meaning as `A = broadcast_axis(B, axis=0,
+ * \return new symbol
+ */
+inline Symbol broadcast_to(const std::string& symbol_name,
+                           Symbol data,
+                           Shape shape = Shape()) {
+  return Operator("broadcast_to")
+           .SetParam("shape", shape)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param src Source input
+ * \return new symbol
+ */
+inline Symbol norm(const std::string& symbol_name,
+                   Symbol src) {
+  return Operator("norm")
+           .SetInput("src", src)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_add(const std::string& symbol_name,
+                            Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_add")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_sub(const std::string& symbol_name,
+                            Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_sub")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_mul(const std::string& symbol_name,
+                            Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_mul")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_div(const std::string& symbol_name,
+                            Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_div")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_power(const std::string& symbol_name,
+                              Symbol lhs,
+                              Symbol rhs) {
+  return Operator("broadcast_power")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_maximum(const std::string& symbol_name,
+                                Symbol lhs,
+                                Symbol rhs) {
+  return Operator("broadcast_maximum")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_minimum(const std::string& symbol_name,
+                                Symbol lhs,
+                                Symbol rhs) {
+  return Operator("broadcast_minimum")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_hypot(const std::string& symbol_name,
+                              Symbol lhs,
+                              Symbol rhs) {
+  return Operator("broadcast_hypot")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_equal(const std::string& symbol_name,
+                              Symbol lhs,
+                              Symbol rhs) {
+  return Operator("broadcast_equal")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_not_equal(const std::string& symbol_name,
+                                  Symbol lhs,
+                                  Symbol rhs) {
+  return Operator("broadcast_not_equal")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_greater(const std::string& symbol_name,
+                                Symbol lhs,
+                                Symbol rhs) {
+  return Operator("broadcast_greater")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_greater_equal(const std::string& symbol_name,
+                                      Symbol lhs,
+                                      Symbol rhs) {
+  return Operator("broadcast_greater_equal")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_lesser(const std::string& symbol_name,
+                               Symbol lhs,
+                               Symbol rhs) {
+  return Operator("broadcast_lesser")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_lesser_equal(const std::string& symbol_name,
+                                     Symbol lhs,
+                                     Symbol rhs) {
+  return Operator("broadcast_lesser_equal")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif
+ * \param symbol_name name of the resulting symbol
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol elemwise_add(const std::string& symbol_name,
+                           Symbol lhs,
+                           Symbol rhs) {
+  return Operator("elemwise_add")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Calculate Smooth L1 Loss(lhs, scalar)
+ *
+ *        From:src/operator/tensor/elemwise_binary_scalar_op_extended.cc:63
+ * \param symbol_name name of the resulting symbol
+ * \param data source input
+ * \param scalar scalar input
+ * \return new symbol
+ */
+inline Symbol smooth_l1(const std::string& symbol_name,
+                        Symbol data,
+                        mx_float scalar) {
+  return Operator("smooth_l1")
+           .SetParam("scalar", scalar)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Perform element sum of inputs
+ *
+ *        From:src/operator/tensor/elemwise_sum.cc:56
+ * \param symbol_name name of the resulting symbol
+ * \param args List of input tensors
+ * \return new symbol
+ */
+inline Symbol ElementWiseSum(const std::string& symbol_name,
+                             const std::vector<Symbol>& args) {
+  return Operator("ElementWiseSum")
+(args)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Negate src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:52
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol negative(const std::string& symbol_name,
+                       Symbol data) {
+  return Operator("negative")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take absolute value of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:58
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol abs(const std::string& symbol_name,
+                  Symbol data) {
+  return Operator("abs")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take sign of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:67
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol sign(const std::string& symbol_name,
+                   Symbol data) {
+  return Operator("sign")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take round of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:76
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol round(const std::string& symbol_name,
+                    Symbol data) {
+  return Operator("round")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take ceil of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:81
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol ceil(const std::string& symbol_name,
+                   Symbol data) {
+  return Operator("ceil")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take floor of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:86
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol floor(const std::string& symbol_name,
+                    Symbol data) {
+  return Operator("floor")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take round of the src to nearest integer
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:91
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol rint(const std::string& symbol_name,
+                   Symbol data) {
+  return Operator("rint")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take round of the src to integer nearest 0
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:96
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol fix(const std::string& symbol_name,
+                  Symbol data) {
+  return Operator("fix")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take square of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:101
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol square(const std::string& symbol_name,
+                     Symbol data) {
+  return Operator("square")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take square root of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:110
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol sqrt(const std::string& symbol_name,
+                   Symbol data) {
+  return Operator("sqrt")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take reciprocal square root of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:119
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol rsqrt(const std::string& symbol_name,
+                    Symbol data) {
+  return Operator("rsqrt")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take exp of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:129
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol exp(const std::string& symbol_name,
+                  Symbol data) {
+  return Operator("exp")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take log of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:135
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol log(const std::string& symbol_name,
+                  Symbol data) {
+  return Operator("log")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take base-10 log of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:141
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol log10(const std::string& symbol_name,
+                    Symbol data) {
+  return Operator("log10")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take base-2 log of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:147
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol log2(const std::string& symbol_name,
+                   Symbol data) {
+  return Operator("log2")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take sin of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:156
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol sin(const std::string& symbol_name,
+                  Symbol data) {
+  return Operator("sin")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take `log(1 + x)` in a numerically stable way
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:165
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol log1p(const std::string& symbol_name,
+                    Symbol data) {
+  return Operator("log1p")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take `exp(x) - 1` in a numerically stable way
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:174
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol expm1(const std::string& symbol_name,
+                    Symbol data) {
+  return Operator("expm1")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take cos of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:183
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol cos(const std::string& symbol_name,
+                  Symbol data) {
+  return Operator("cos")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take tan of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:192
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol tan(const std::string& symbol_name,
+                  Symbol data) {
+  return Operator("tan")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take arcsin of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:201
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol arcsin(const std::string& symbol_name,
+                     Symbol data) {
+  return Operator("arcsin")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take arccos of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:210
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol arccos(const std::string& symbol_name,
+                     Symbol data) {
+  return Operator("arccos")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take arctan of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:219
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol arctan(const std::string& symbol_name,
+                     Symbol data) {
+  return Operator("arctan")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take degrees of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:228
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol degrees(const std::string& symbol_name,
+                      Symbol data) {
+  return Operator("degrees")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take radians of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:237
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol radians(const std::string& symbol_name,
+                      Symbol data) {
+  return Operator("radians")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take sinh of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:246
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol sinh(const std::string& symbol_name,
+                   Symbol data) {
+  return Operator("sinh")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take cosh of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:255
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol cosh(const std::string& symbol_name,
+                   Symbol data) {
+  return Operator("cosh")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take tanh of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:264
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol tanh(const std::string& symbol_name,
+                   Symbol data) {
+  return Operator("tanh")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take arcsinh of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:273
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol arcsinh(const std::string& symbol_name,
+                      Symbol data) {
+  return Operator("arcsinh")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take arccosh of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:282
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol arccosh(const std::string& symbol_name,
+                      Symbol data) {
+  return Operator("arccosh")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take arctanh of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:291
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol arctanh(const std::string& symbol_name,
+                      Symbol data) {
+  return Operator("arctanh")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take the gamma function (extension of the factorial function) of the
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:300
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol gamma(const std::string& symbol_name,
+                    Symbol data) {
+  return Operator("gamma")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Take gammaln (log of the absolute value of gamma(x)) of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:309
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol gammaln(const std::string& symbol_name,
+                      Symbol data) {
+  return Operator("gammaln")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Map integer index to vector representations (embeddings). Those
+ *        embeddings are learnable parameters. For a input of shape (d1, ...,
+ *        dK), the output shape is (d1, ..., dK, output_dim). All the input
+ *
+ *        From:src/operator/tensor/indexing_op.cc:17
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the EmbeddingOp.
+ * \param weight Embedding weight matrix.
+ * \param input_dim vocabulary size of the input indices.
+ * \param output_dim dimension of the embedding vectors.
+ * \return new symbol
+ */
+inline Symbol Embedding(const std::string& symbol_name,
+                        Symbol data,
+                        Symbol weight,
+                        int input_dim,
+                        int output_dim) {
+  return Operator("Embedding")
+           .SetParam("input_dim", input_dim)
+           .SetParam("output_dim", output_dim)
+           .SetInput("data", data)
+           .SetInput("weight", weight)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Reshape input according to a target shape spec.
+ *        The target shape is a tuple and can be a simple list of dimensions
+ *        such as (12,3) or it can incorporate special codes that correspond
+ *        The special codes are all expressed as integers less than 1. These
+ *        codes effectively refer to a machine that pops input dims off the
+ *        beginning of the input dims list and pushes resulting output dims
+ *        onto the end of the output dims list, which starts empty. The codes
+ *        0  Copy     Pop one input dim and push it onto the output dims
+ *        -1  Infer    Push a dim that is inferred later from all other output
+ *        -2  CopyAll  Pop all remaining input dims and push them onto output
+ *        -3  Merge2   Pop two input dims, multiply them, and push result
+ *        -4  Split2   Pop one input dim, and read two next target shape specs,
+ *        push them both onto output dims (either can be -1 and will
+ *        be inferred from the other
+ *        The exact mathematical behavior of these codes is given in the
+ *        description of the 'shape' parameter. All non-codes (positive
+ *        integers) just pop a dim off the input dims (if any), throw it away,
+ *        Examples:
+ *        Type     Input      Target            Output
+ *        Copy     (2,3,4)    (4,0,2)           (4,3,2)
+ *        Copy     (2,3,4)    (2,0,0)           (2,3,4)
+ *        Infer    (2,3,4)    (6,1,-1)          (6,1,4)
+ *        Infer    (2,3,4)    (3,-1,8)          (3,1,8)
+ *        CopyAll  (9,8,7)    (-2)              (9,8,7)
+ *        CopyAll  (9,8,7)    (9,-2)            (9,8,7)
+ *        CopyAll  (9,8,7)    (-2,1,1)          (9,8,7,1,1)
+ *        Merge2   (3,4)      (-3)              (12)
+ *        Merge2   (3,4,5)    (-3,0)            (12,5)
+ *        Merge2   (3,4,5)    (0,-3)            (3,20)
+ *        Merge2   (3,4,5,6)  (-3,0,0)          (12,5,6)
+ *        Merge2   (3,4,5,6)  (-3,-2)           (12,5,6)
+ *        Split2   (12)       (-4,6,2)          (6,2)
+ *        Split2   (12)       (-4,2,6)          (2,6)
+ *        Split2   (12)       (-4,-1,6)         (2,6)
+ *        Split2   (12,9)     (-4,2,6,0)        (2,6,9)
+ *        Split2   (12,9,9,9) (-4,2,6,-2)       (2,6,9,9,9)
+ *        Split2   (12,12)    (-4,2,-1,-4,-1,2) (2,6,6,2)
+ *
+ *
+ *        From:src/operator/tensor/matrix_op.cc:61
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to reshape.
+ * \param target_shape (Deprecated! Use shape instead.) Target new shape. One
+ *        and only one dim can be 0, in which case it will be inferred from
+ * \param keep_highest (Deprecated! Use shape instead.) Whether keep the
+ *        highest dim unchanged.If set to true, then the first dim in
+ * \param shape Target shape, a tuple, t=(t_1,t_2,..,t_m).
+ *        Let the input dims be s=(s_1,s_2,..,s_n).
+ *        The output dims u=(u_1,u_2,..,u_p) are computed from s and t.
+ *        The target shape tuple elements t_i are read in order, and used to
+ *        t_i:       meaning:      behavior:
+ *        +ve        explicit      u_p = t_i
+ *        0          copy          u_p = s_i
+ *        -1         infer         u_p = (Prod s_i) / (Prod u_j | j != p)
+ *        -2         copy all      u_p = s_i, u_p+1 = s_i+1, ...
+ *        -3         merge two     u_p = s_i * s_i+1
+ *        -4,a,b     split two     u_p = a, u_p+1 = b | a * b = s_i
+ *        The split directive (-4) in the target shape tuple is followed by two
+ *        dimensions, one of which can be -1, which means it will be inferred
+ *        The can only be one globally inferred dimension (-1), aside from any
+ * \param reverse Whether to match the shapes from the backward. If reverse is
+ *        true, 0 values in the `shape` argument will be searched from the
+ *        backward. E.g the original shape is (10, 5, 4) and the shape
+ *        argument is (-1, 0). If reverse is true, the new shape should be
+ * \return new symbol
+ */
+inline Symbol Reshape(const std::string& symbol_name,
+                      Symbol data,
+                      Shape target_shape = Shape(0,0),
+                      bool keep_highest = false,
+                      Shape shape = Shape(),
+                      bool reverse = false) {
+  return Operator("Reshape")
+           .SetParam("target_shape", target_shape)
+           .SetParam("keep_highest", keep_highest)
+           .SetParam("shape", shape)
+           .SetParam("reverse", reverse)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Flatten input into 2D by collapsing all the higher dimensions.
+ *        A (d1, d2, ..., dK) tensor is flatten to (d1, d2* ... *dK) matrix.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to reshape.
+ * \return new symbol
+ */
+inline Symbol Flatten(const std::string& symbol_name,
+                      Symbol data) {
+  return Operator("Flatten")
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Transpose the input tensor and return a new one
+ *
+ *        From:src/operator/tensor/matrix_op.cc:93
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axes Target axis order. By default the axes will be inverted.
+ * \return new symbol
+ */
+inline Symbol transpose(const std::string& symbol_name,
+                        Symbol data,
+                        Shape axes = Shape()) {
+  return Operator("transpose")
+           .SetParam("axes", axes)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Expand the shape of array by inserting a new axis.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:121
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axis Position (amongst axes) where new axis is to be inserted.
+ * \return new symbol
+ */
+inline Symbol expand_dims(const std::string& symbol_name,
+                          Symbol data,
+                          int axis) {
+  return Operator("expand_dims")
+           .SetParam("axis", axis)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif (Crop the input tensor and return a new one.
+ *
+ *        Requirements
+ *        ------------
+ *        - the input and output (if explicitly given) are of the same data
+ *        and on the same device.
+ *        )
+ *
+ *        From:src/operator/tensor/matrix_op.cc:142
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param begin starting coordinates
+ * \param end ending coordinates
+ * \return new symbol
+ */
+inline Symbol crop(const std::string& symbol_name,
+                   Symbol data,
+                   Shape begin,
+                   Shape end) {
+  return Operator("crop")
+           .SetParam("begin", begin)
+           .SetParam("end", end)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Slice the input along certain axis and return a sliced array.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:197
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axis The axis to be sliced
+ * \param begin The beginning index to be sliced
+ * \param end The end index to be sliced
+ * \return new symbol
+ */
+inline Symbol slice_axis(const std::string& symbol_name,
+                         Symbol data,
+                         int axis,
+                         int begin,
+                         int end) {
+  return Operator("slice_axis")
+           .SetParam("axis", axis)
+           .SetParam("begin", begin)
+           .SetParam("end", end)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Flip the input tensor along axis and return a new one.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:216
+ * \param symbol_name name of the resulting symbol
+ * \param data Source input
+ * \param axis The dimension to flip
+ * \return new symbol
+ */
+inline Symbol flip(const std::string& symbol_name,
+                   Symbol data,
+                   int axis) {
+  return Operator("flip")
+           .SetParam("axis", axis)
+           .SetInput("data", data)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Calculate dot product of two matrices or two vectors.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:228
+ * \param symbol_name name of the resulting symbol
+ * \param lhs Left input
+ * \param rhs Right input
+ * \param transpose_a True if the first matrix is transposed.
+ * \param transpose_b True if the second matrix is tranposed.
+ * \return new symbol
+ */
+inline Symbol dot(const std::string& symbol_name,
+                  Symbol lhs,
+                  Symbol rhs,
+                  bool transpose_a = false,
+                  bool transpose_b = false) {
+  return Operator("dot")
+           .SetParam("transpose_a", transpose_a)
+           .SetParam("transpose_b", transpose_b)
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Calculate batched dot product of two matrices. (batch, M, K)
+ *
+ *        From:src/operator/tensor/matrix_op.cc:254
+ * \param symbol_name name of the resulting symbol
+ * \param lhs Left input
+ * \param rhs Right input
+ * \param axis The dimension to flip
+ * \return new symbol
+ */
+inline Symbol batch_dot(const std::string& symbol_name,
+                        Symbol lhs,
+                        Symbol rhs,
+                        int axis) {
+  return Operator("batch_dot")
+           .SetParam("axis", axis)
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Sample a uniform distribution
+ * \param symbol_name name of the resulting symbol
+ * \param low The lower bound of distribution
+ * \param high The upper bound of distribution
+ * \param shape The shape of the output
+ * \param ctx Context of output, in format [cpu|gpu|cpu_pinned](n).Only used
+ * \return new symbol
+ */
+inline Symbol uniform(const std::string& symbol_name,
+                      mx_float low = 0,
+                      mx_float high = 1,
+                      Shape shape = Shape(),
+                      const std::string& ctx = "") {
+  return Operator("uniform")
+           .SetParam("low", low)
+           .SetParam("high", high)
+           .SetParam("shape", shape)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Sample a normal distribution
+ * \param symbol_name name of the resulting symbol
+ * \param loc Mean of the distribution.
+ * \param scale Standard deviation of the distribution.
+ * \param shape The shape of the output
+ * \param ctx Context of output, in format [cpu|gpu|cpu_pinned](n).Only used
+ * \return new symbol
+ */
+inline Symbol normal(const std::string& symbol_name,
+                     mx_float loc = 0,
+                     mx_float scale = 1,
+                     Shape shape = Shape(),
+                     const std::string& ctx = "") {
+  return Operator("normal")
+           .SetParam("loc", loc)
+           .SetParam("scale", scale)
+           .SetParam("shape", shape)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Calculate cross_entropy(lhs, one_hot(rhs))
+ *
+ *        From:src/operator/loss_binary_op.cc:12
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data
+ * \param label Input label
+ * \return new symbol
+ */
+inline Symbol softmax_cross_entropy(const std::string& symbol_name,
+                                    Symbol data,
+                                    Symbol label) {
+  return Operator("softmax_cross_entropy")
+           .SetInput("data", data)
+           .SetInput("label", label)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Updater function for sgd optimizer
+ * \param symbol_name name of the resulting symbol
+ * \return new symbol
+ */
+inline Symbol sgd_update(const std::string& symbol_name) {
+  return Operator("sgd_update")
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Updater function for sgd optimizer
+ * \param symbol_name name of the resulting symbol
+ * \return new symbol
+ */
+inline Symbol sgd_mom_update(const std::string& symbol_name) {
+  return Operator("sgd_mom_update")
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Updater function for adam optimizer
+ * \param symbol_name name of the resulting symbol
+ * \return new symbol
+ */
+inline Symbol adam_update(const std::string& symbol_name) {
+  return Operator("adam_update")
+           .CreateSymbol(symbol_name);
+}
+
+/*! \breif Activation function to be applied.
  */
 enum class ActivationActType {
   relu = 0,
@@ -27,12 +1392,21 @@ enum class ActivationActType {
 };
 
 /*!
- * \breif Apply activation function to input.
- *        Softmax Activation is only available with CUDNN on GPUand will be
- *        computed at each location across channel if input is 4D.
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to activation function. 
- * \param act_type Activation function to be applied. 
+ * \breif Elementwise activation function.
+ *
+ *        The following activation types are supported (operations are applied
+ *        scalar of the input tensor):
+ *
+ *        - `relu`: Rectified Linear Unit, `y = max(x, 0)`
+ *        - `sigmoid`: `y = 1 / (1 + exp(-x))`
+ *        - `tanh`: Hyperbolic tangent, `y = (exp(x) - exp(-x)) / (exp(x) +
+ *        - `softrelu`: Soft ReLU, or SoftPlus, `y = log(1 + exp(x))`
+ *
+ *        See `LeakyReLU` for other activations with parameters.
+ *
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to activation function.
+ * \param act_type Activation function to be applied.
  * \return new symbol
  */
 inline Symbol Activation(const std::string& symbol_name,
@@ -51,15 +1425,14 @@ inline Symbol Activation(const std::string& symbol_name,
 }
 
 /*!
- * \breif Apply batch normalization to input. 
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to batch normalization.
- * \param eps Epsilon to prevent div 0.
- * \param momentum Momentum for moving average.
- * \param fix_gamma Fix gamma while training.
+ * \breif Apply batch normalization to input.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to batch normalization
+ * \param eps Epsilon to prevent div 0
+ * \param momentum Momentum for moving average
+ * \param fix_gamma Fix gamma while training
  * \param use_global_stats Whether use global moving statistics instead of
  *        local batch-norm. This will force change batch-norm into a scale
- *        shift operator.
  * \return new symbol
  */
 inline Symbol BatchNorm(const std::string& symbol_name,
@@ -78,9 +1451,9 @@ inline Symbol BatchNorm(const std::string& symbol_name,
 }
 
 /*!
- * \breif Get output from a symbol and pass 0 gradient back.
- * \param symbol_name name of the resulting symbol.
- * \param data Input data. 
+ * \breif Get output from a symbol and pass 0 gradient back
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data.
  * \return new symbol
  */
 inline Symbol BlockGrad(const std::string& symbol_name,
@@ -90,60 +1463,7 @@ inline Symbol BlockGrad(const std::string& symbol_name,
            .CreateSymbol(symbol_name);
 }
 
-/*!
- * \breif (Deprecated! Use sum_axis instead.
- *        ) Take sum of the src.The result will be ndarray of shape (1,) on the
- *        same device.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol sum(const std::string& symbol_name,
-                  Symbol lhs,
-                  Symbol rhs) {
-  return Operator("sum")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Take sum of the src in the given axis.
- *        axis=-1 means to reduce all the dimensions.The keepdims option has
- *        the same meaning as Numpy.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol sum_axis(const std::string& symbol_name,
-                       Symbol lhs,
-                       Symbol rhs) {
-  return Operator("sum_axis")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Broadcast data in the given axis to the given size.
- *        The original size of the broadcasting axis must be 1.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol broadcast_axis(const std::string& symbol_name,
-                             Symbol lhs,
-                             Symbol rhs) {
-  return Operator("broadcast_axis")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*! \breif Target data type. 
+/*! \breif Target data type.
  */
 enum class CastDtype {
   float16 = 0,
@@ -154,10 +1474,10 @@ enum class CastDtype {
 };
 
 /*!
- * \breif Cast array to a different data type. 
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to cast function. 
- * \param dtype Target data type. 
+ * \breif Cast array to a different data type.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to cast function.
+ * \param dtype Target data type.
  * \return new symbol
  */
 inline Symbol Cast(const std::string& symbol_name,
@@ -177,11 +1497,11 @@ inline Symbol Cast(const std::string& symbol_name,
 }
 
 /*!
- * \breif Perform an feature concat on channel dim (defaut is 1) over all.
- * \param symbol_name name of the resulting symbol.
- * \param data List of tensors to concatenate.
- * \param num_args Number of inputs to be concated. 
- * \param dim the dimension to be concated. 
+ * \breif Perform a feature concat on channel dim (defaut is 1) over all
+ * \param symbol_name name of the resulting symbol
+ * \param data List of tensors to concatenate
+ * \param num_args Number of inputs to be concated.
+ * \param dim the dimension to be concated.
  * \return new symbol
  */
 inline Symbol Concat(const std::string& symbol_name,
@@ -195,22 +1515,59 @@ inline Symbol Concat(const std::string& symbol_name,
            .CreateSymbol(symbol_name);
 }
 
+/*! \breif Whether to pick convolution algo by running performance test.
+ *        Leads to higher startup time but may give faster speed. Options are:
+ *        'off': no tuning
+ *        'limited_workspace': run test and pick the fastest algorithm that
+ *        'fastest': pick the fastest algorithm and ignore workspace limit.
+ *        If set to None (default), behavior is determined by environment
+ *        variable MXNET_CUDNN_AUTOTUNE_DEFAULT: 0 for off,
+ *        1 for limited workspace (default), 2 for fastest.
+ */
+enum class ConvolutionCudnnTune {
+  None = 0,
+  fastest = 1,
+  limited_workspace = 2,
+  off = 3
+};
+
+/*! \breif Set layout for input, output and weight. Empty for
+ *        default layout: NCHW for 2d and NCDHW for 3d.
+ */
+enum class ConvolutionLayout {
+  None = 0,
+  NCDHW = 1,
+  NCHW = 2,
+  NDHWC = 3,
+  NHWC = 4
+};
+
 /*!
- * \breif Apply convolution to input then add a bias. 
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to the ConvolutionOp. 
- * \param weight Weight matrix. 
- * \param bias Bias parameter. 
- * \param kernel convolution kernel size: (y, x).
- * \param num_filter convolution filter(channel) number.
- * \param stride convolution stride: (y, x).
- * \param dilate convolution dilate: (y, x).
- * \param pad pad for convolution: (y, x).
- * \param num_group Number of groups partition.
- *        This option is not supported by CuDNN, you can use SliceChannel to
- *        num_group,apply convolution and concat instead to achieve the same need.
- * \param workspace Tmp workspace for convolution (MB). 
- * \param no_bias Whether to disable bias parameter. 
+ * \breif Apply convolution to input then add a bias.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the ConvolutionOp.
+ * \param weight Weight matrix.
+ * \param bias Bias parameter.
+ * \param kernel convolution kernel size: (h, w) or (d, h, w)
+ * \param num_filter convolution filter(channel) number
+ * \param stride convolution stride: (h, w) or (d, h, w)
+ * \param dilate convolution dilate: (h, w) or (d, h, w)
+ * \param pad pad for convolution: (h, w) or (d, h, w)
+ * \param num_group Number of group partitions. Equivalent to slicing input
+ *        partitions, apply convolution on each, then concatenate the results
+ * \param workspace Maximum tmp workspace allowed for convolution (MB).
+ * \param no_bias Whether to disable bias parameter.
+ * \param cudnn_tune Whether to pick convolution algo by running performance
+ *        Leads to higher startup time but may give faster speed. Options are:
+ *        'off': no tuning
+ *        'limited_workspace': run test and pick the fastest algorithm that
+ *        'fastest': pick the fastest algorithm and ignore workspace limit.
+ *        If set to None (default), behavior is determined by environment
+ *        variable MXNET_CUDNN_AUTOTUNE_DEFAULT: 0 for off,
+ *        1 for limited workspace (default), 2 for fastest.
+ * \param cudnn_off Turn off cudnn for this layer.
+ * \param layout Set layout for input, output and weight. Empty for
+ *        default layout: NCHW for 2d and NCDHW for 3d.
  * \return new symbol
  */
 inline Symbol Convolution(const std::string& symbol_name,
@@ -219,12 +1576,28 @@ inline Symbol Convolution(const std::string& symbol_name,
                           Symbol bias,
                           Shape kernel,
                           int num_filter,
-                          Shape stride = Shape(1,1),
-                          Shape dilate = Shape(1,1),
-                          Shape pad = Shape(0,0),
+                          Shape stride = Shape(),
+                          Shape dilate = Shape(),
+                          Shape pad = Shape(),
                           int num_group = 1,
-                          int64_t workspace = 512,
-                          bool no_bias = false) {
+                          int64_t workspace = 1024,
+                          bool no_bias = false,
+                          ConvolutionCudnnTune cudnn_tune = ConvolutionCudnnTune::None,
+                          bool cudnn_off = false,
+                          ConvolutionLayout layout = ConvolutionLayout::None) {
+  static const char *ConvolutionCudnnTuneValues[] = {
+    "None",
+    "fastest",
+    "limited_workspace",
+    "off"
+  };
+  static const char *ConvolutionLayoutValues[] = {
+    "None",
+    "NCDHW",
+    "NCHW",
+    "NDHWC",
+    "NHWC"
+  };
   return Operator("Convolution")
            .SetParam("kernel", kernel)
            .SetParam("num_filter", num_filter)
@@ -234,6 +1607,9 @@ inline Symbol Convolution(const std::string& symbol_name,
            .SetParam("num_group", num_group)
            .SetParam("workspace", workspace)
            .SetParam("no_bias", no_bias)
+           .SetParam("cudnn_tune", ConvolutionCudnnTuneValues[int(cudnn_tune)])
+           .SetParam("cudnn_off", cudnn_off)
+           .SetParam("layout", ConvolutionLayoutValues[int(layout)])
            .SetInput("data", data)
            .SetInput("weight", weight)
            .SetInput("bias", bias)
@@ -241,20 +1617,51 @@ inline Symbol Convolution(const std::string& symbol_name,
 }
 
 /*!
+ * \breif Apply correlation to inputs
+ * \param symbol_name name of the resulting symbol
+ * \param data1 Input data1 to the correlation.
+ * \param data2 Input data2 to the correlation.
+ * \param kernel_size kernel size for Correlation must be an odd number
+ * \param max_displacement Max displacement of Correlation
+ * \param stride1 stride1 quantize data1 globally
+ * \param stride2 stride2 quantize data2 within the neighborhood centered
+ * \param pad_size pad for Correlation
+ * \param is_multiply operation type is either multiplication or subduction
+ * \return new symbol
+ */
+inline Symbol Correlation(const std::string& symbol_name,
+                          Symbol data1,
+                          Symbol data2,
+                          int kernel_size = 1,
+                          int max_displacement = 1,
+                          int stride1 = 1,
+                          int stride2 = 1,
+                          int pad_size = 0,
+                          bool is_multiply = true) {
+  return Operator("Correlation")
+           .SetParam("kernel_size", kernel_size)
+           .SetParam("max_displacement", max_displacement)
+           .SetParam("stride1", stride1)
+           .SetParam("stride2", stride2)
+           .SetParam("pad_size", pad_size)
+           .SetParam("is_multiply", is_multiply)
+           .SetInput("data1", data1)
+           .SetInput("data2", data2)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
  * \breif Crop the 2nd and 3rd dim of input data, with the corresponding size
  *        of h_w or with width and height of the second input symbol, i.e.,
  *        with one input, we need h_w to specify the crop height and width,
- *        otherwise the second input symbol's size will be used
- * \param symbol_name name of the resulting symbol.
+ * \param symbol_name name of the resulting symbol
  * \param data Tensor or List of Tensors, the second input will be used as
- *        crop_like shape reference
  * \param num_args Number of inputs for crop, if equals one, then we will use
  *        the h_wfor crop height and width, else if equals two, then we will
- *        use the heightand width of the second input symbol, we name crop_like here
- * \param offset crop offset coordinate: (y, x).
- * \param h_w crop height and weight: (h, w).
+ *        use the heightand width of the second input symbol, we name
+ * \param offset crop offset coordinate: (y, x)
+ * \param h_w crop height and weight: (h, w)
  * \param center_crop If set to true, then it will use be the center_crop,or it
- *        will crop using the shape of crop_like
  * \return new symbol
  */
 inline Symbol Crop(const std::string& symbol_name,
@@ -273,10 +1680,9 @@ inline Symbol Crop(const std::string& symbol_name,
 }
 
 /*!
- * \breif Custom operator implemented in frontend. 
- * \param symbol_name name of the resulting symbol.
- * \param op_type Type of custom operator.
- *        Must be registered first.
+ * \breif Custom operator implemented in frontend.
+ * \param symbol_name name of the resulting symbol
+ * \param op_type Type of custom operator. Must be registered first.
  * \return new symbol
  */
 inline Symbol Custom(const std::string& symbol_name,
@@ -286,18 +1692,21 @@ inline Symbol Custom(const std::string& symbol_name,
 }
 
 /*!
- * \breif Apply deconvolution to input then add a bias. 
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to the DeconvolutionOp. 
- * \param weight Weight matrix. 
- * \param bias Bias parameter. 
- * \param kernel deconvolution kernel size: (y, x).
- * \param num_filter deconvolution filter(channel) number.
- * \param stride deconvolution stride: (y, x).
- * \param pad pad for deconvolution: (y, x).
- * \param num_group number of groups partition.
- * \param workspace Tmp workspace for deconvolution (MB).
- * \param no_bias Whether to disable bias parameter. 
+ * \breif Apply deconvolution to input then add a bias.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the DeconvolutionOp.
+ * \param weight Weight matrix.
+ * \param bias Bias parameter.
+ * \param kernel deconvolution kernel size: (y, x)
+ * \param num_filter deconvolution filter(channel) number
+ * \param stride deconvolution stride: (y, x)
+ * \param pad pad for deconvolution: (y, x), a good number is : (kernel-1)/2,
+ *        if target_shape set, pad will be ignored and will be computed
+ * \param adj adjustment for output shape: (y, x), if target_shape set, adj
+ * \param target_shape output shape with targe shape : (y, x)
+ * \param num_group number of groups partition
+ * \param workspace Tmp workspace for deconvolution (MB)
+ * \param no_bias Whether to disable bias parameter.
  * \return new symbol
  */
 inline Symbol Deconvolution(const std::string& symbol_name,
@@ -308,6 +1717,8 @@ inline Symbol Deconvolution(const std::string& symbol_name,
                             int num_filter,
                             Shape stride = Shape(1,1),
                             Shape pad = Shape(0,0),
+                            Shape adj = Shape(0,0),
+                            Shape target_shape = Shape(0,0),
                             int num_group = 1,
                             int64_t workspace = 512,
                             bool no_bias = true) {
@@ -316,6 +1727,8 @@ inline Symbol Deconvolution(const std::string& symbol_name,
            .SetParam("num_filter", num_filter)
            .SetParam("stride", stride)
            .SetParam("pad", pad)
+           .SetParam("adj", adj)
+           .SetParam("target_shape", target_shape)
            .SetParam("num_group", num_group)
            .SetParam("workspace", workspace)
            .SetParam("no_bias", no_bias)
@@ -327,9 +1740,13 @@ inline Symbol Deconvolution(const std::string& symbol_name,
 
 /*!
  * \breif Apply dropout to input.
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to dropout. 
- * \param p Fraction of the input that gets dropped out at training time.
+ *        During training, each element of the input is randomly set to zero
+ *        And then the whole tensor is rescaled by 1/(1-p) to keep the
+ *        before applying dropout. During the test time, this behaves as an
+ *
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to dropout.
+ * \param p Fraction of the input that gets dropped out at training time
  * \return new symbol
  */
 inline Symbol Dropout(const std::string& symbol_name,
@@ -342,307 +1759,16 @@ inline Symbol Dropout(const std::string& symbol_name,
 }
 
 /*!
- * \breif lhs add rhs with broadcast.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol broadcast_plus(const std::string& symbol_name,
-                             Symbol lhs,
-                             Symbol rhs) {
-  return Operator("broadcast_plus")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif lhs minus rhs with broadcast.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol broadcast_minus(const std::string& symbol_name,
-                              Symbol lhs,
-                              Symbol rhs) {
-  return Operator("broadcast_minus")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif lhs multiple rhs with broadcast.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol broadcast_mul(const std::string& symbol_name,
-                            Symbol lhs,
-                            Symbol rhs) {
-  return Operator("broadcast_mul")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif lhs divide rhs with broadcast.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol broadcast_div(const std::string& symbol_name,
-                            Symbol lhs,
-                            Symbol rhs) {
-  return Operator("broadcast_div")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Perform an elementwise sum over all the inputs. 
- * \param symbol_name name of the resulting symbol.
- * \param num_args Number of inputs to be summed. 
- * \return new symbol
- */
-inline Symbol ElementWiseSum(const std::string& symbol_name,
-                             int num_args) {
-  return Operator("ElementWiseSum")
-           .SetParam("num_args", num_args)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Take absolute value of the src.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol abs(const std::string& symbol_name,
-                  Symbol lhs,
-                  Symbol rhs) {
-  return Operator("abs")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Take sign value of the src.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol sign(const std::string& symbol_name,
-                   Symbol lhs,
-                   Symbol rhs) {
-  return Operator("sign")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Take round value of the src.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol round(const std::string& symbol_name,
-                    Symbol lhs,
-                    Symbol rhs) {
-  return Operator("round")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Take ceil value of the src.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol ceil(const std::string& symbol_name,
-                   Symbol lhs,
-                   Symbol rhs) {
-  return Operator("ceil")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Take floor value of the src.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol floor(const std::string& symbol_name,
-                    Symbol lhs,
-                    Symbol rhs) {
-  return Operator("floor")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Take square of the src.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol square(const std::string& symbol_name,
-                     Symbol lhs,
-                     Symbol rhs) {
-  return Operator("square")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Take sqrt of the src.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol sqrt(const std::string& symbol_name,
-                   Symbol lhs,
-                   Symbol rhs) {
-  return Operator("sqrt")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Take rsqrt of the src.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol rsqrt(const std::string& symbol_name,
-                    Symbol lhs,
-                    Symbol rhs) {
-  return Operator("rsqrt")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Take exp of the src.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol exp(const std::string& symbol_name,
-                  Symbol lhs,
-                  Symbol rhs) {
-  return Operator("exp")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Take log of the src.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol log(const std::string& symbol_name,
-                  Symbol lhs,
-                  Symbol rhs) {
-  return Operator("log")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Take cos of the src.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol cos(const std::string& symbol_name,
-                  Symbol lhs,
-                  Symbol rhs) {
-  return Operator("cos")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Take sin of the src.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol sin(const std::string& symbol_name,
-                  Symbol lhs,
-                  Symbol rhs) {
-  return Operator("sin")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Get embedding for one-hot input.
- *        A n-dimensional input tensor will be trainsformed into a
- *        (n+1)-dimensional tensor, where a new dimension is added for the
- *        embedding results.
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to the EmbeddingOp. 
- * \param weight Enbedding weight matrix. 
- * \param input_dim input dim of one-hot encoding.
- * \param output_dim output dim of embedding.
- * \return new symbol
- */
-inline Symbol Embedding(const std::string& symbol_name,
-                        Symbol data,
-                        Symbol weight,
-                        int input_dim,
-                        int output_dim) {
-  return Operator("Embedding")
-           .SetParam("input_dim", input_dim)
-           .SetParam("output_dim", output_dim)
-           .SetInput("data", data)
-           .SetInput("weight", weight)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Apply matrix multiplication to input then add a bias. 
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to the FullyConnectedOp. 
- * \param weight Weight matrix. 
- * \param bias Bias parameter. 
- * \param num_hidden Number of hidden nodes of the output. 
- * \param no_bias Whether to disable bias parameter. 
+ * \breif Apply matrix multiplication to input then add a bias.
+ *        It maps the input of shape `(batch_size, input_dim)` to the shape of
+ *        `(batch_size, num_hidden)`. Learnable parameters include the weights
+ *        of the linear transform and an optional bias vector.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the FullyConnectedOp.
+ * \param weight Weight matrix.
+ * \param bias Bias parameter.
+ * \param num_hidden Number of hidden nodes of the output.
+ * \param no_bias Whether to disable bias parameter.
  * \return new symbol
  */
 inline Symbol FullyConnected(const std::string& symbol_name,
@@ -661,12 +1787,12 @@ inline Symbol FullyConnected(const std::string& symbol_name,
 }
 
 /*!
- * \breif Apply a sparse regularization to the output a sigmoid activation function. 
- * \param symbol_name name of the resulting symbol.
- * \param data Input data. 
- * \param sparseness_target The sparseness target.
- * \param penalty The tradeoff parameter for the sparseness penalty.
- * \param momentum The momentum for running average.
+ * \breif Apply a sparse regularization to the output a sigmoid activation
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data.
+ * \param sparseness_target The sparseness target
+ * \param penalty The tradeoff parameter for the sparseness penalty
+ * \param momentum The momentum for running average
  * \return new symbol
  */
 inline Symbol IdentityAttachKLSparseReg(const std::string& symbol_name,
@@ -683,22 +1809,74 @@ inline Symbol IdentityAttachKLSparseReg(const std::string& symbol_name,
 }
 
 /*!
- * \breif Set the l2 norm of each instance to a constant. 
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to the L2NormalizationOp. 
- * \param eps Epsilon to prevent div 0.
+ * \breif An operator taking in a n-dimensional input tensor (n > 2), and
+ *        normalizing the input by subtracting the mean and variance
+ *        calculated over the spatial dimensions. This is an implemention of
+ *        the operator described in "Instance Normalization: The Missing
+ *        Ingredient for Fast Stylization", D. Ulyanov, A. Vedaldi, V.
+ *        Lempitsky, 2016 (arXiv:1607.08022v2). This layer is similar to batch
+ *        normalization, with two differences: first, the normalization is
+ *        carried out per example ('instance'), not over a batch. Second, the
+ *        same normalization is applied both at test and train time. This
+ * \param symbol_name name of the resulting symbol
+ * \param data A n-dimensional tensor (n > 2) of the form [batch, channel,
+ * \param gamma A vector of length 'channel', which multiplies the normalized
+ * \param beta A vector of length 'channel', which is added to the product of
+ * \param eps Epsilon to prevent division by 0.
+ * \return new symbol
+ */
+inline Symbol InstanceNorm(const std::string& symbol_name,
+                           Symbol data,
+                           Symbol gamma,
+                           Symbol beta,
+                           mx_float eps = 0.001) {
+  return Operator("InstanceNorm")
+           .SetParam("eps", eps)
+           .SetInput("data", data)
+           .SetInput("gamma", gamma)
+           .SetInput("beta", beta)
+           .CreateSymbol(symbol_name);
+}
+
+/*! \breif Normalization Mode. If set to instance, this operator will compute a
+ *        norm for each instance in the batch; this is the default mode. If
+ *        set to channel, this operator will compute a cross channel norm at
+ *        each position of each instance. If set to spatial, this operator
+ */
+enum class L2NormalizationMode {
+  channel = 0,
+  instance = 1,
+  spatial = 2
+};
+
+/*!
+ * \breif Set the l2 norm of each instance to a constant.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the L2NormalizationOp.
+ * \param eps Epsilon to prevent div 0
+ * \param mode Normalization Mode. If set to instance, this operator will
+ *        compute a norm for each instance in the batch; this is the default
+ *        mode. If set to channel, this operator will compute a cross channel
+ *        norm at each position of each instance. If set to spatial, this
  * \return new symbol
  */
 inline Symbol L2Normalization(const std::string& symbol_name,
                               Symbol data,
-                              mx_float eps = 1e-010) {
+                              mx_float eps = 1e-10,
+                              L2NormalizationMode mode = L2NormalizationMode::instance) {
+  static const char *L2NormalizationModeValues[] = {
+    "channel",
+    "instance",
+    "spatial"
+  };
   return Operator("L2Normalization")
            .SetParam("eps", eps)
+           .SetParam("mode", L2NormalizationModeValues[int(mode)])
            .SetInput("data", data)
            .CreateSymbol(symbol_name);
 }
 
-/*! \breif Activation function to be applied. 
+/*! \breif Activation function to be applied.
  */
 enum class LeakyReLUActType {
   elu = 0,
@@ -708,16 +1886,13 @@ enum class LeakyReLUActType {
 };
 
 /*!
- * \breif Apply activation function to input. 
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to activation function. 
- * \param act_type Activation function to be applied. 
- * \param slope Init slope for the activation.
- *        (For leaky and elu only)
- * \param lower_bound Lower bound of random slope.
- *        (For rrelu only)
- * \param upper_bound Upper bound of random slope.
- *        (For rrelu only)
+ * \breif Apply activation function to input.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to activation function.
+ * \param act_type Activation function to be applied.
+ * \param slope Init slope for the activation. (For leaky and elu only)
+ * \param lower_bound Lower bound of random slope. (For rrelu only)
+ * \param upper_bound Upper bound of random slope. (For rrelu only)
  * \return new symbol
  */
 inline Symbol LeakyReLU(const std::string& symbol_name,
@@ -742,30 +1917,13 @@ inline Symbol LeakyReLU(const std::string& symbol_name,
 }
 
 /*!
- * \breif Calculate cross_entropy(lhs, one_hot(rhs)).
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol softmax_cross_entropy(const std::string& symbol_name,
-                                    Symbol lhs,
-                                    Symbol rhs) {
-  return Operator("softmax_cross_entropy")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Apply convolution to input then add a bias. 
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to the ConvolutionOp. 
- * \param nsize normalization window width in elements. 
+ * \breif Apply convolution to input then add a bias.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the ConvolutionOp.
+ * \param nsize normalization window width in elements.
  * \param alpha value of the alpha variance scaling parameter in the
- *        normalization formula
- * \param beta value of the beta power parameter in the normalization formula.
- * \param knorm value of the k parameter in normalization formula.
+ * \param beta value of the beta power parameter in the normalization formula
+ * \param knorm value of the k parameter in normalization formula
  * \return new symbol
  */
 inline Symbol LRN(const std::string& symbol_name,
@@ -783,57 +1941,86 @@ inline Symbol LRN(const std::string& symbol_name,
            .CreateSymbol(symbol_name);
 }
 
+/*! \breif If set to null, op will not normalize on output gradient.If set to
+ *        batch, op will normalize gradient by divide batch size.If set to
+ */
+enum class MakeLossNormalization {
+  batch = 0,
+  null = 1,
+  valid = 2
+};
+
 /*!
- * \breif Get output from a symbol and pass 1 gradient back.
- *        This is used as a terminal loss if unary and binary operator are used
- *        to composite a loss with no declaration of backward dependency
- * \param symbol_name name of the resulting symbol.
- * \param data Input data. 
- * \param grad_scale gradient scale as a supplement to unary and binary operators.
+ * \breif Get output from a symbol and pass 1 gradient back. This is used as a
+ *        terminal loss if unary and binary operator are used to composite a
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data.
+ * \param grad_scale gradient scale as a supplement to unary and binary
+ * \param valid_thresh regard element valid when x > valid_thresh, this is used
+ * \param normalization If set to null, op will not normalize on output
+ *        gradient.If set to batch, op will normalize gradient by divide batch
+ *        size.If set to valid, op will normalize gradient by divide # sample
  * \return new symbol
  */
 inline Symbol MakeLoss(const std::string& symbol_name,
                        Symbol data,
-                       mx_float grad_scale = 1) {
+                       mx_float grad_scale = 1,
+                       mx_float valid_thresh = 0,
+                       MakeLossNormalization normalization = MakeLossNormalization::null) {
+  static const char *MakeLossNormalizationValues[] = {
+    "batch",
+    "null",
+    "valid"
+  };
   return Operator("MakeLoss")
            .SetParam("grad_scale", grad_scale)
+           .SetParam("valid_thresh", valid_thresh)
+           .SetParam("normalization", MakeLossNormalizationValues[int(normalization)])
            .SetInput("data", data)
            .CreateSymbol(symbol_name);
 }
 
+/*! \breif Padding type to use. "constant" pads all values with a constant
+ *        value, the value of which can be specified with the constant_value
+ */
+enum class PadMode {
+  constant = 0,
+  edge = 1
+};
+
 /*!
- * \breif Transpose the input matrix and return a new one.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
+ * \breif Pads an n-dimensional input tensor. Allows for precise control of the
+ *        padding type and how much padding to apply on both sides of a given
+ * \param symbol_name name of the resulting symbol
+ * \param data An n-dimensional input tensor.
+ * \param mode Padding type to use. "constant" pads all values with a constant
+ *        value, the value of which can be specified with the constant_value
+ * \param pad_width A tuple of padding widths of length 2*r, where r is the
+ *        rank of the input tensor, specifying number of values padded to the
+ *        edges of each axis. (before_1, after_1, ... , before_N, after_N)
+ *        unique pad widths for each axis. Equivalent to pad_width in
+ * \param constant_value This option is only used when mode is "constant". This
+ *        value will be used as the padding value. Defaults to 0 if not
  * \return new symbol
  */
-inline Symbol transpose(const std::string& symbol_name,
-                        Symbol lhs,
-                        Symbol rhs) {
-  return Operator("transpose")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
+inline Symbol Pad(const std::string& symbol_name,
+                  Symbol data,
+                  PadMode mode,
+                  Shape pad_width,
+                  double constant_value = 0) {
+  static const char *PadModeValues[] = {
+    "constant",
+    "edge"
+  };
+  return Operator("Pad")
+           .SetParam("mode", PadModeValues[int(mode)])
+           .SetParam("pad_width", pad_width)
+           .SetParam("constant_value", constant_value)
+           .SetInput("data", data)
            .CreateSymbol(symbol_name);
 }
 
-/*!
- * \breif Calculate dot product of two matrices or two vectors.
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol dot(const std::string& symbol_name,
-                  Symbol lhs,
-                  Symbol rhs) {
-  return Operator("dot")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*! \breif Pooling type to be applied. 
+/*! \breif Pooling type to be applied.
  */
 enum class PoolingPoolType {
   avg = 0,
@@ -841,16 +2028,25 @@ enum class PoolingPoolType {
   sum = 2
 };
 
+/*! \breif Pooling convention to be applied.kValid is default setting of Mxnet
+ *        and rounds down the output pooling size.kFull is compatible with
+ */
+enum class PoolingPoolingConvention {
+  full = 0,
+  valid = 1
+};
+
 /*!
- * \breif Perform spatial pooling on inputs. 
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to the pooling operator. 
- * \param kernel pooling kernel size: (y, x).
- * \param pool_type Pooling type to be applied. 
+ * \breif Perform spatial pooling on inputs.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the pooling operator.
+ * \param kernel pooling kernel size: (y, x) or (d, y, x)
+ * \param pool_type Pooling type to be applied.
  * \param global_pool Ignore kernel size, do global pooling based on current
- *        input feature map. This is useful for input with different shape
- * \param stride stride: for pooling (y, x).
- * \param pad pad for pooling: (y, x).
+ * \param pooling_convention Pooling convention to be applied.kValid is default
+ *        setting of Mxnet and rounds down the output pooling size.kFull is
+ * \param stride stride: for pooling (y, x) or (d, y, x)
+ * \param pad pad for pooling: (y, x) or (d, y, x)
  * \return new symbol
  */
 inline Symbol Pooling(const std::string& symbol_name,
@@ -858,6 +2054,7 @@ inline Symbol Pooling(const std::string& symbol_name,
                       Shape kernel,
                       PoolingPoolType pool_type,
                       bool global_pool = false,
+                      PoolingPoolingConvention pooling_convention = PoolingPoolingConvention::valid,
                       Shape stride = Shape(1,1),
                       Shape pad = Shape(0,0)) {
   static const char *PoolingPoolTypeValues[] = {
@@ -865,10 +2062,15 @@ inline Symbol Pooling(const std::string& symbol_name,
     "max",
     "sum"
   };
+  static const char *PoolingPoolingConventionValues[] = {
+    "full",
+    "valid"
+  };
   return Operator("Pooling")
            .SetParam("kernel", kernel)
            .SetParam("pool_type", PoolingPoolTypeValues[int(pool_type)])
            .SetParam("global_pool", global_pool)
+           .SetParam("pooling_convention", PoolingPoolingConventionValues[int(pooling_convention)])
            .SetParam("stride", stride)
            .SetParam("pad", pad)
            .SetInput("data", data)
@@ -876,11 +2078,11 @@ inline Symbol Pooling(const std::string& symbol_name,
 }
 
 /*!
- * \breif Use linear regression for final output, this is used on final output of a net. 
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to function. 
- * \param label Input label to function. 
- * \param grad_scale Scale the gradient by a float factor.
+ * \breif Use linear regression for final output, this is used on final output
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to function.
+ * \param label Input label to function.
+ * \param grad_scale Scale the gradient by a float factor
  * \return new symbol
  */
 inline Symbol LinearRegressionOutput(const std::string& symbol_name,
@@ -896,11 +2098,10 @@ inline Symbol LinearRegressionOutput(const std::string& symbol_name,
 
 /*!
  * \breif Use mean absolute error regression for final output, this is used on
- *        final output of a net.
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to function. 
- * \param label Input label to function. 
- * \param grad_scale Scale the gradient by a float factor.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to function.
+ * \param label Input label to function.
+ * \param grad_scale Scale the gradient by a float factor
  * \return new symbol
  */
 inline Symbol MAERegressionOutput(const std::string& symbol_name,
@@ -915,13 +2116,12 @@ inline Symbol MAERegressionOutput(const std::string& symbol_name,
 }
 
 /*!
- * \breif Use Logistic regression for final output, this is used on final output of a net.
+ * \breif Use Logistic regression for final output, this is used on final
  *        Logistic regression is suitable for binary classification or
- *        probability prediction tasks.
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to function. 
- * \param label Input label to function. 
- * \param grad_scale Scale the gradient by a float factor.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to function.
+ * \param label Input label to function.
+ * \param grad_scale Scale the gradient by a float factor
  * \return new symbol
  */
 inline Symbol LogisticRegressionOutput(const std::string& symbol_name,
@@ -935,58 +2135,74 @@ inline Symbol LogisticRegressionOutput(const std::string& symbol_name,
            .CreateSymbol(symbol_name);
 }
 
+/*! \breif the type of RNN to compute
+ */
+enum class RNNMode {
+  gru = 0,
+  lstm = 1,
+  rnn_relu = 2,
+  rnn_tanh = 3
+};
+
 /*!
- * \breif Reshape input to target shape.
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to reshape. 
- * \param target_shape (Deprecated! Use shape instead.
- *        ) Target new shape. One and only one dim can be 0, in which case it
- *        will be inferred from the rest of dims
- * \param keep_highest (Deprecated! Use shape instead.
- *        ) Whether keep the highest dim unchanged.If set to yes, than the
- *        first dim in target_shape is ignored,and always fixed as input
- * \param shape Target new shape.
- *        If the dim is same, set it to 0. If the dim is set to be -1, it will
- *        be inferred from the rest of dims. One and only one dim can be -1
+ * \breif Apply a recurrent layer to input.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to RNN
+ * \param parameters Vector of all RNN trainable parameters concatenated
+ * \param state initial hidden state of the RNN
+ * \param state_cell initial cell state for LSTM networks (only for LSTM)
+ * \param state_size size of the state for each layer
+ * \param num_layers number of stacked layers
+ * \param mode the type of RNN to compute
+ * \param bidirectional whether to use bidirectional recurrent layers
+ * \param p Dropout probability, fraction of the input that gets dropped out at
+ * \param state_outputs Whether to have the states as symbol outputs.
  * \return new symbol
  */
-inline Symbol Reshape(const std::string& symbol_name,
-                      Symbol data,
-                      Shape shape = Shape()) {
-  return Operator("Reshape")
-           .SetParam("shape", shape)
+inline Symbol RNN(const std::string& symbol_name,
+                  Symbol data,
+                  Symbol parameters,
+                  Symbol state,
+                  Symbol state_cell,
+                  int state_size,
+                  int num_layers,
+                  RNNMode mode,
+                  bool bidirectional = false,
+                  mx_float p = 0,
+                  bool state_outputs = false) {
+  static const char *RNNModeValues[] = {
+    "gru",
+    "lstm",
+    "rnn_relu",
+    "rnn_tanh"
+  };
+  return Operator("RNN")
+           .SetParam("state_size", state_size)
+           .SetParam("num_layers", num_layers)
+           .SetParam("mode", RNNModeValues[int(mode)])
+           .SetParam("bidirectional", bidirectional)
+           .SetParam("p", p)
+           .SetParam("state_outputs", state_outputs)
            .SetInput("data", data)
+           .SetInput("parameters", parameters)
+           .SetInput("state", state)
+           .SetInput("state_cell", state_cell)
            .CreateSymbol(symbol_name);
 }
 
 /*!
- * \breif Flatten input.
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to flatten. 
- * \return new symbol
- */
-inline Symbol Flatten(const std::string& symbol_name,
-                      Symbol data) {
-  return Operator("Flatten")
-           .SetInput("data", data)
-           .CreateSymbol(symbol_name);
-}
-
-/*!
- * \breif Performs region-of-interest pooling on inputs.
- *        Resize bounding box coordinates by spatial_scale and crop input
- *        feature maps accordingly. The cropped feature maps are pooled by max
- *        pooling to a fixed size output indicated by pooled_size. batch_size
- *        will change to the number of region bounding boxes after ROIPooling
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to the pooling operator, a 4D Feature maps.
- * \param rois Bounding box coordinates, a 2D array of [[batch_index, x1, y1, x2, y2]].
- *        (x1, y1) and (x2, y2) are top left and down right corners of
- *        designated region of interest. batch_index indicates the index of
- *        corresponding image in the input data
- * \param pooled_size fix pooled size: (h, w).
+ * \breif Performs region-of-interest pooling on inputs. Resize bounding box
+ *        coordinates by spatial_scale and crop input feature maps
+ *        accordingly. The cropped feature maps are pooled by max pooling to a
+ *        fixed size output indicated by pooled_size. batch_size will change
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the pooling operator, a 4D Feature maps
+ * \param rois Bounding box coordinates, a 2D array of [[batch_index, x1, y1,
+ *        x2, y2]]. (x1, y1) and (x2, y2) are top left and down right corners
+ *        of designated region of interest. batch_index indicates the index of
+ * \param pooled_size fix pooled size: (h, w)
  * \param spatial_scale Ratio of input feature map height (or w) to raw image
- *        height (or w). Equals the reciprocal of total stride in convolutional layers
+ *        height (or w). Equals the reciprocal of total stride in
  * \return new symbol
  */
 inline Symbol ROIPooling(const std::string& symbol_name,
@@ -1003,11 +2219,90 @@ inline Symbol ROIPooling(const std::string& symbol_name,
 }
 
 /*!
- * \breif Slice input equally along specified axis.
- * \param symbol_name name of the resulting symbol.
- * \param num_outputs Number of outputs to be sliced. 
- * \param axis Dimension along which to slice. 
- * \param squeeze_axis If true AND the sliced dimension becomes 1, squeeze that dimension. 
+ * \breif Takes the last element of a sequence. Takes an n-dimensional tensor
+ *        of the form [max sequence length, batchsize, other dims] and returns
+ *        a (n-1)-dimensional tensor of the form [batchsize, other dims]. This
+ *        operator takes an optional input tensor sequence_length of positive
+ *        ints of dimension [batchsize] when the sequence_length option is set
+ *        to true. This allows the operator to handle variable-length
+ *        sequences. If sequence_length is false, then each example in the
+ * \param symbol_name name of the resulting symbol
+ * \param data n-dimensional input tensor of the form [max sequence length,
+ * \param sequence_length vector of sequence lengths of size batchsize
+ * \param use_sequence_length If set to true, this layer takes in extra input
+ * \return new symbol
+ */
+inline Symbol SequenceLast(const std::string& symbol_name,
+                           Symbol data,
+                           Symbol sequence_length,
+                           bool use_sequence_length = false) {
+  return Operator("SequenceLast")
+           .SetParam("use_sequence_length", use_sequence_length)
+           .SetInput("data", data)
+           .SetInput("sequence_length", sequence_length)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Sets all elements outside the sequence to a constant value. Takes an
+ *        n-dimensional tensor of the form [max sequence length, batchsize,
+ *        other dims] and returns a tensor of the same shape. This operator
+ *        takes an optional input tensor sequence_length of positive ints of
+ *        dimension [batchsize] when the sequence_length option is set to
+ *        true. This allows the operator to handle variable-length sequences.
+ *        If sequence_length is false, then each example in the batch is
+ *        assumed to have the max sequence length, and this operator becomes
+ * \param symbol_name name of the resulting symbol
+ * \param data n-dimensional input tensor of the form [max sequence length,
+ * \param sequence_length vector of sequence lengths of size batchsize
+ * \param use_sequence_length If set to true, this layer takes in extra input
+ * \param value The value to be used as a mask.
+ * \return new symbol
+ */
+inline Symbol SequenceMask(const std::string& symbol_name,
+                           Symbol data,
+                           Symbol sequence_length,
+                           bool use_sequence_length = false,
+                           mx_float value = 0) {
+  return Operator("SequenceMask")
+           .SetParam("use_sequence_length", use_sequence_length)
+           .SetParam("value", value)
+           .SetInput("data", data)
+           .SetInput("sequence_length", sequence_length)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Reverses the elements of each sequence. Takes an n-dimensional tensor
+ *        of the form [max sequence length, batchsize, other dims] and returns
+ *        a tensor of the same shape. This operator takes an optional input
+ *        tensor sequence_length of positive ints of dimension [batchsize]
+ *        when the sequence_length option is set to true. This allows the
+ *        operator to handle variable-length sequences. If sequence_length is
+ *        false, then each example in the batch is assumed to have the max
+ * \param symbol_name name of the resulting symbol
+ * \param data n-dimensional input tensor of the form [max sequence length,
+ * \param sequence_length vector of sequence lengths of size batchsize
+ * \param use_sequence_length If set to true, this layer takes in extra input
+ * \return new symbol
+ */
+inline Symbol SequenceReverse(const std::string& symbol_name,
+                              Symbol data,
+                              Symbol sequence_length,
+                              bool use_sequence_length = false) {
+  return Operator("SequenceReverse")
+           .SetParam("use_sequence_length", use_sequence_length)
+           .SetInput("data", data)
+           .SetInput("sequence_length", sequence_length)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Slice input equally along specified axis
+ * \param symbol_name name of the resulting symbol
+ * \param num_outputs Number of outputs to be sliced.
+ * \param axis Dimension along which to slice.
+ * \param squeeze_axis If true AND the sliced dimension becomes 1, squeeze that
  * \return new symbol
  */
 inline Symbol SliceChannel(const std::string& symbol_name,
@@ -1021,28 +2316,10 @@ inline Symbol SliceChannel(const std::string& symbol_name,
            .CreateSymbol(symbol_name);
 }
 
-/*!
- * \breif Calculate Smooth L1 Loss(lhs, scalar).
- * \param symbol_name name of the resulting symbol.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol smooth_l1(const std::string& symbol_name,
-                        Symbol lhs,
-                        Symbol rhs) {
-  return Operator("smooth_l1")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol(symbol_name);
-}
-
-/*! \breif Softmax Mode.
- *        If set to instance, this operator will compute a softmax for each
- *        instance in the batch; this is the default mode. If set to channel,
- *        this operator will compute a num_channel-class softmax at each
- *        position of each instance; this can be used for fully convolutional
- *        network, image segmentation, etc.
+/*! \breif Softmax Mode. If set to instance, this operator will compute a
+ *        softmax for each instance in the batch; this is the default mode. If
+ *        set to channel, this operator will compute a num_channel-class
+ *        softmax at each position of each instance; this can be used for
  */
 enum class SoftmaxActivationMode {
   channel = 0,
@@ -1050,21 +2327,18 @@ enum class SoftmaxActivationMode {
 };
 
 /*!
- * \breif Apply softmax activation to input.
- *        This is intended for internal layers. For output (loss layer) please
- *        use SoftmaxOutput. If type=instance, this operator will compute a
- *        softmax for each instance in the batch; this is the default mode. If
- *        type=channel, this operator will compute a num_channel-class softmax
- *        at each position of each instance; this can be used for fully
- *        convolutional network, image segmentation, etc.
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to activation function. 
- * \param mode Softmax Mode.
- *        If set to instance, this operator will compute a softmax for each
- *        instance in the batch; this is the default mode. If set to channel,
+ * \breif Apply softmax activation to input. This is intended for internal
+ *        layers. For output (loss layer) please use SoftmaxOutput. If
+ *        mode=instance, this operator will compute a softmax for each
+ *        instance in the batch; this is the default mode. If mode=channel,
  *        this operator will compute a num_channel-class softmax at each
  *        position of each instance; this can be used for fully convolutional
- *        network, image segmentation, etc.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to activation function.
+ * \param mode Softmax Mode. If set to instance, this operator will compute a
+ *        softmax for each instance in the batch; this is the default mode. If
+ *        set to channel, this operator will compute a num_channel-class
+ *        softmax at each position of each instance; this can be used for
  * \return new symbol
  */
 inline Symbol SoftmaxActivation(const std::string& symbol_name,
@@ -1080,9 +2354,8 @@ inline Symbol SoftmaxActivation(const std::string& symbol_name,
            .CreateSymbol(symbol_name);
 }
 
-/*! \breif If set to null, op will do nothing on output gradient.
- *        If set to batch, op will normalize gradient by divide batch sizeIf
- *        set to valid, op will normalize gradient by divide sample not ignored
+/*! \breif If set to null, op will do nothing on output gradient.If set to
+ *        batch, op will normalize gradient by divide batch sizeIf set to
  */
 enum class SoftmaxOutputNormalization {
   batch = 0,
@@ -1091,20 +2364,21 @@ enum class SoftmaxOutputNormalization {
 };
 
 /*!
- * \breif Perform a softmax transformation on input, backprop with logloss. 
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to softmax. 
- * \param label Label data. 
- * \param grad_scale Scale the gradient by a float factor.
+ * \breif Perform a softmax transformation on input, backprop with logloss.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to softmax.
+ * \param label Label data, can also be probability value with same shape as
+ * \param grad_scale Scale the gradient by a float factor
  * \param ignore_label the label value will be ignored during backward (only
- *        works if use_ignore is set to be true).
  * \param multi_output If set to true, for a (n,k,x_1,..,x_n) dimensional input
- *        tensor, softmax will generate n*x_1*...*x_n output, each has k classes
+ *        tensor, softmax will generate n*x_1*...*x_n output, each has k
  * \param use_ignore If set to true, the ignore_label value will not contribute
- *        to the backward gradient
- * \param normalization If set to null, op will do nothing on output gradient.
- *        If set to batch, op will normalize gradient by divide batch sizeIf
- *        set to valid, op will normalize gradient by divide sample not ignored
+ * \param preserve_shape If true, for a (n_1, n_2, ..., n_d, k) dimensional
+ *        input tensor, softmax will generate (n1, n2, ..., n_d, k) output,
+ * \param normalization If set to null, op will do nothing on output
+ *        gradient.If set to batch, op will normalize gradient by divide batch
+ *        sizeIf set to valid, op will normalize gradient by divide sample not
+ * \param out_grad Apply weighting from output gradient
  * \return new symbol
  */
 inline Symbol SoftmaxOutput(const std::string& symbol_name,
@@ -1114,7 +2388,9 @@ inline Symbol SoftmaxOutput(const std::string& symbol_name,
                             mx_float ignore_label = -1,
                             bool multi_output = false,
                             bool use_ignore = false,
-                            SoftmaxOutputNormalization normalization = SoftmaxOutputNormalization::null) {
+                            bool preserve_shape = false,
+                            SoftmaxOutputNormalization normalization = SoftmaxOutputNormalization::null,
+                            bool out_grad = false) {
   static const char *SoftmaxOutputNormalizationValues[] = {
     "batch",
     "null",
@@ -1125,15 +2401,16 @@ inline Symbol SoftmaxOutput(const std::string& symbol_name,
            .SetParam("ignore_label", ignore_label)
            .SetParam("multi_output", multi_output)
            .SetParam("use_ignore", use_ignore)
+           .SetParam("preserve_shape", preserve_shape)
            .SetParam("normalization", SoftmaxOutputNormalizationValues[int(normalization)])
+           .SetParam("out_grad", out_grad)
            .SetInput("data", data)
            .SetInput("label", label)
            .CreateSymbol(symbol_name);
 }
 
-/*! \breif If set to null, op will do nothing on output gradient.
- *        If set to batch, op will normalize gradient by divide batch sizeIf
- *        set to valid, op will normalize gradient by divide sample not ignored
+/*! \breif If set to null, op will do nothing on output gradient.If set to
+ *        batch, op will normalize gradient by divide batch sizeIf set to
  */
 enum class SoftmaxNormalization {
   batch = 0,
@@ -1142,20 +2419,20 @@ enum class SoftmaxNormalization {
 };
 
 /*!
- * \breif DEPRECATED: Perform a softmax transformation on input.
- *        Please use SoftmaxOutput
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to softmax. 
- * \param grad_scale Scale the gradient by a float factor.
+ * \breif DEPRECATED: Perform a softmax transformation on input. Please use
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to softmax.
+ * \param grad_scale Scale the gradient by a float factor
  * \param ignore_label the label value will be ignored during backward (only
- *        works if use_ignore is set to be true).
  * \param multi_output If set to true, for a (n,k,x_1,..,x_n) dimensional input
- *        tensor, softmax will generate n*x_1*...*x_n output, each has k classes
+ *        tensor, softmax will generate n*x_1*...*x_n output, each has k
  * \param use_ignore If set to true, the ignore_label value will not contribute
- *        to the backward gradient
- * \param normalization If set to null, op will do nothing on output gradient.
- *        If set to batch, op will normalize gradient by divide batch sizeIf
- *        set to valid, op will normalize gradient by divide sample not ignored
+ * \param preserve_shape If true, for a (n_1, n_2, ..., n_d, k) dimensional
+ *        input tensor, softmax will generate (n1, n2, ..., n_d, k) output,
+ * \param normalization If set to null, op will do nothing on output
+ *        gradient.If set to batch, op will normalize gradient by divide batch
+ *        sizeIf set to valid, op will normalize gradient by divide sample not
+ * \param out_grad Apply weighting from output gradient
  * \return new symbol
  */
 inline Symbol Softmax(const std::string& symbol_name,
@@ -1164,7 +2441,9 @@ inline Symbol Softmax(const std::string& symbol_name,
                       mx_float ignore_label = -1,
                       bool multi_output = false,
                       bool use_ignore = false,
-                      SoftmaxNormalization normalization = SoftmaxNormalization::null) {
+                      bool preserve_shape = false,
+                      SoftmaxNormalization normalization = SoftmaxNormalization::null,
+                      bool out_grad = false) {
   static const char *SoftmaxNormalizationValues[] = {
     "batch",
     "null",
@@ -1175,17 +2454,89 @@ inline Symbol Softmax(const std::string& symbol_name,
            .SetParam("ignore_label", ignore_label)
            .SetParam("multi_output", multi_output)
            .SetParam("use_ignore", use_ignore)
+           .SetParam("preserve_shape", preserve_shape)
            .SetParam("normalization", SoftmaxNormalizationValues[int(normalization)])
+           .SetParam("out_grad", out_grad)
            .SetInput("data", data)
            .CreateSymbol(symbol_name);
 }
 
+/*! \breif transformation type
+ */
+enum class SpatialTransformerTransformType {
+  affine = 0
+};
+
+/*! \breif sampling type
+ */
+enum class SpatialTransformerSamplerType {
+  bilinear = 0
+};
+
 /*!
- * \breif Apply swapaxis to input. 
- * \param symbol_name name of the resulting symbol.
- * \param data Input data to the SwapAxisOp. 
- * \param dim1 the first axis to be swapped. 
- * \param dim2 the second axis to be swapped. 
+ * \breif Apply spatial transformer to input feature map.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the SpatialTransformerOp.
+ * \param loc localisation net, the output dim should be 6 when transform_type
+ *        is affine, and the name of loc symbol should better starts with
+ *        'stn_loc', so that initialization it with iddentify tranform, or you
+ * \param transform_type transformation type
+ * \param sampler_type sampling type
+ * \param target_shape output shape(h, w) of spatial transformer: (y, x)
+ * \return new symbol
+ */
+inline Symbol SpatialTransformer(const std::string& symbol_name,
+                                 Symbol data,
+                                 Symbol loc,
+                                 SpatialTransformerTransformType transform_type,
+                                 SpatialTransformerSamplerType sampler_type,
+                                 Shape target_shape = Shape(0,0)) {
+  static const char *SpatialTransformerTransformTypeValues[] = {
+    "affine"
+  };
+  static const char *SpatialTransformerSamplerTypeValues[] = {
+    "bilinear"
+  };
+  return Operator("SpatialTransformer")
+           .SetParam("transform_type", SpatialTransformerTransformTypeValues[int(transform_type)])
+           .SetParam("sampler_type", SpatialTransformerSamplerTypeValues[int(sampler_type)])
+           .SetParam("target_shape", target_shape)
+           .SetInput("data", data)
+           .SetInput("loc", loc)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Support Vector Machine based transformation on input, backprop L2-SVM
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to svm.
+ * \param label Label data.
+ * \param margin Scale the DType(param_.margin) for activation size
+ * \param regularization_coefficient Scale the coefficient responsible for
+ * \param use_linear If set true, uses L1-SVM objective function. Default uses
+ * \return new symbol
+ */
+inline Symbol SVMOutput(const std::string& symbol_name,
+                        Symbol data,
+                        Symbol label,
+                        mx_float margin = 1,
+                        mx_float regularization_coefficient = 1,
+                        bool use_linear = false) {
+  return Operator("SVMOutput")
+           .SetParam("margin", margin)
+           .SetParam("regularization_coefficient", regularization_coefficient)
+           .SetParam("use_linear", use_linear)
+           .SetInput("data", data)
+           .SetInput("label", label)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Apply swapaxis to input.
+ * \param symbol_name name of the resulting symbol
+ * \param data Input data to the SwapAxisOp.
+ * \param dim1 the first axis to be swapped.
+ * \param dim2 the second axis to be swapped.
  * \return new symbol
  */
 inline Symbol SwapAxis(const std::string& symbol_name,
@@ -1199,17 +2550,15 @@ inline Symbol SwapAxis(const std::string& symbol_name,
            .CreateSymbol(symbol_name);
 }
 
-/*! \breif upsampling method.
+/*! \breif upsampling method
  */
 enum class UpSamplingSampleType {
   bilinear = 0,
   nearest = 1
 };
 
-/*! \breif How to handle multiple input.
- *        concat means concatenate upsampled images along the channel
- *        dimension. sum means add all images together, only available for
- *        nearest neighbor upsampling.
+/*! \breif How to handle multiple input. concat means concatenate upsampled
+ *        images along the channel dimension. sum means add all images
  */
 enum class UpSamplingMultiInputMode {
   concat = 0,
@@ -1217,22 +2566,20 @@ enum class UpSamplingMultiInputMode {
 };
 
 /*!
- * \breif Perform nearest neighboor/bilinear up sampling to inputs.
- * \param symbol_name name of the resulting symbol.
- * \param data Array of tensors to upsample.
- * \param scale Up sampling scale.
- * \param sample_type upsampling method.
- * \param num_args Number of inputs to be upsampled.
- *        For nearest neighbor upsampling, this can be 1-N; the size of output
- *        will be(scale*h_0,scale*w_0) and all other inputs will be upsampled
- *        to thesame size. For bilinear upsampling this must be 2; 1 input and 1 weight.
- * \param num_filter Input filter.
- *        Only used by nearest sample_type.
- * \param multi_input_mode How to handle multiple input.
- *        concat means concatenate upsampled images along the channel
- *        dimension. sum means add all images together, only available for
- *        nearest neighbor upsampling.
- * \param workspace Tmp workspace for deconvolution (MB).
+ * \breif Perform nearest neighboor/bilinear up sampling to inputs
+ * \param symbol_name name of the resulting symbol
+ * \param data Array of tensors to upsample
+ * \param scale Up sampling scale
+ * \param sample_type upsampling method
+ * \param num_args Number of inputs to be upsampled. For nearest neighbor
+ *        upsampling, this can be 1-N; the size of output will
+ *        be(scale*h_0,scale*w_0) and all other inputs will be upsampled to
+ *        thesame size. For bilinear upsampling this must be 2; 1 input and 1
+ * \param num_filter Input filter. Only used by bilinear sample_type.
+ * \param multi_input_mode How to handle multiple input. concat means
+ *        concatenate upsampled images along the channel dimension. sum means
+ *        add all images together, only available for nearest neighbor
+ * \param workspace Tmp workspace for deconvolution (MB)
  * \return new symbol
  */
 inline Symbol UpSampling(const std::string& symbol_name,
@@ -1263,11 +2610,1288 @@ inline Symbol UpSampling(const std::string& symbol_name,
 }
 
 /*!
- * \breif Apply activation function to input.
- *        Softmax Activation is only available with CUDNN on GPUand will be
- *        computed at each location across channel if input is 4D.
- * \param data Input data to activation function. 
- * \param act_type Activation function to be applied. 
+ * \breif Choose one element from each line(row for python, column for R/Julia)
+ *        in lhs according to index indicated by rhs. This function assume rhs
+ * \param symbol_name name of the resulting symbol
+ * \param lhs Left operand to the function.
+ * \param rhs Right operand to the function.
+ * \return new symbol
+ */
+inline Symbol choose_element_0index(const std::string& symbol_name,
+                                    Symbol lhs,
+                                    Symbol rhs) {
+  return Operator("choose_element_0index")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Fill one element of each line(row for python, column for R/Julia) in
+ *        lhs according to index indicated by rhs and values indicated by mhs.
+ * \param symbol_name name of the resulting symbol
+ * \param lhs Left operand to the function.
+ * \param mhs Middle operand to the function.
+ * \param rhs Right operand to the function.
+ * \return new symbol
+ */
+inline Symbol fill_element_0index(const std::string& symbol_name,
+                                  Symbol lhs,
+                                  Symbol mhs,
+                                  Symbol rhs) {
+  return Operator("fill_element_0index")
+           .SetInput("lhs", lhs)
+           .SetInput("mhs", mhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Clip ndarray elements to range (a_min, a_max)
+ * \param symbol_name name of the resulting symbol
+ * \param src Source input
+ * \param a_min Minimum value
+ * \param a_max Maximum value
+ * \return new symbol
+ */
+inline Symbol clip(const std::string& symbol_name,
+                   Symbol src,
+                   mx_float a_min,
+                   mx_float a_max) {
+  return Operator("clip")
+           .SetParam("a_min", a_min)
+           .SetParam("a_max", a_max)
+           .SetInput("src", src)
+           .CreateSymbol(symbol_name);
+}
+
+/*!
+ * \breif Compute argmax
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_index.cc:11
+ * \param data Source input
+ * \param axis Empty or unsigned. The axis to perform the reduction.If left
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol argmax(Symbol data,
+                     int axis = -1,
+                     bool keepdims = false) {
+  return Operator("argmax")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Compute argmin
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_index.cc:15
+ * \param data Source input
+ * \param axis Empty or unsigned. The axis to perform the reduction.If left
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol argmin(Symbol data,
+                     int axis = -1,
+                     bool keepdims = false) {
+  return Operator("argmin")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param src Source input
+ * \return new symbol
+ */
+inline Symbol argmax_channel(Symbol src) {
+  return Operator("argmax_channel")
+           .SetInput("src", src)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Sum src along axis. If axis is empty, global reduction is performed
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:17
+ * \param data Source input
+ * \param axis Empty or unsigned or tuple. The axes to perform the reduction.If
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol sum(Symbol data,
+                  Shape axis = Shape(),
+                  bool keepdims = false) {
+  return Operator("sum")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Compute product of src along axis. If axis is empty, global reduction
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:27
+ * \param data Source input
+ * \param axis Empty or unsigned or tuple. The axes to perform the reduction.If
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol prod(Symbol data,
+                   Shape axis = Shape(),
+                   bool keepdims = false) {
+  return Operator("prod")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Sum src along axis, ignoring NaN values. If axis is empty, global
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:37
+ * \param data Source input
+ * \param axis Empty or unsigned or tuple. The axes to perform the reduction.If
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol nansum(Symbol data,
+                     Shape axis = Shape(),
+                     bool keepdims = false) {
+  return Operator("nansum")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Compute product of src along axis, ignoring NaN values. If axis is
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:47
+ * \param data Source input
+ * \param axis Empty or unsigned or tuple. The axes to perform the reduction.If
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol nanprod(Symbol data,
+                      Shape axis = Shape(),
+                      bool keepdims = false) {
+  return Operator("nanprod")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Compute max along axis. If axis is empty, global reduction is
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:57
+ * \param data Source input
+ * \param axis Empty or unsigned or tuple. The axes to perform the reduction.If
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol max(Symbol data,
+                  Shape axis = Shape(),
+                  bool keepdims = false) {
+  return Operator("max")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Compute min along axis. If axis is empty, global reduction is
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:67
+ * \param data Source input
+ * \param axis Empty or unsigned or tuple. The axes to perform the reduction.If
+ * \param keepdims If true, the axis which is reduced is left in the result as
+ * \return new symbol
+ */
+inline Symbol min(Symbol data,
+                  Shape axis = Shape(),
+                  bool keepdims = false) {
+  return Operator("min")
+           .SetParam("axis", axis)
+           .SetParam("keepdims", keepdims)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Broadcast src along axis
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:76
+ * \param data Source input
+ * \param axis The axes to perform the broadcasting.
+ * \param size Target sizes of the broadcasting axes.
+ * \return new symbol
+ */
+inline Symbol broadcast_axis(Symbol data,
+                             Shape axis = Shape(),
+                             Shape size = Shape()) {
+  return Operator("broadcast_axis")
+           .SetParam("axis", axis)
+           .SetParam("size", size)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Broadcast src to shape
+ *
+ *        From:src/operator/tensor/broadcast_reduce_op_value.cc:83
+ * \param data Source input
+ * \param shape The shape of the desired array. We can set the dim to zero if
+ *        it's same as the original. E.g `A = broadcast_to(B, shape=(10, 0,
+ *        0))` has the same meaning as `A = broadcast_axis(B, axis=0,
+ * \return new symbol
+ */
+inline Symbol broadcast_to(Symbol data,
+                           Shape shape = Shape()) {
+  return Operator("broadcast_to")
+           .SetParam("shape", shape)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param src Source input
+ * \return new symbol
+ */
+inline Symbol norm(Symbol src) {
+  return Operator("norm")
+           .SetInput("src", src)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_add(Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_add")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_sub(Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_sub")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_mul(Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_mul")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_div(Symbol lhs,
+                            Symbol rhs) {
+  return Operator("broadcast_div")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_power(Symbol lhs,
+                              Symbol rhs) {
+  return Operator("broadcast_power")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_maximum(Symbol lhs,
+                                Symbol rhs) {
+  return Operator("broadcast_maximum")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_minimum(Symbol lhs,
+                                Symbol rhs) {
+  return Operator("broadcast_minimum")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_hypot(Symbol lhs,
+                              Symbol rhs) {
+  return Operator("broadcast_hypot")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_equal(Symbol lhs,
+                              Symbol rhs) {
+  return Operator("broadcast_equal")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_not_equal(Symbol lhs,
+                                  Symbol rhs) {
+  return Operator("broadcast_not_equal")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_greater(Symbol lhs,
+                                Symbol rhs) {
+  return Operator("broadcast_greater")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_greater_equal(Symbol lhs,
+                                      Symbol rhs) {
+  return Operator("broadcast_greater_equal")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_lesser(Symbol lhs,
+                               Symbol rhs) {
+  return Operator("broadcast_lesser")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol broadcast_lesser_equal(Symbol lhs,
+                                     Symbol rhs) {
+  return Operator("broadcast_lesser_equal")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif
+ * \param lhs first input
+ * \param rhs second input
+ * \return new symbol
+ */
+inline Symbol elemwise_add(Symbol lhs,
+                           Symbol rhs) {
+  return Operator("elemwise_add")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Calculate Smooth L1 Loss(lhs, scalar)
+ *
+ *        From:src/operator/tensor/elemwise_binary_scalar_op_extended.cc:63
+ * \param data source input
+ * \param scalar scalar input
+ * \return new symbol
+ */
+inline Symbol smooth_l1(Symbol data,
+                        mx_float scalar) {
+  return Operator("smooth_l1")
+           .SetParam("scalar", scalar)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Perform element sum of inputs
+ *
+ *        From:src/operator/tensor/elemwise_sum.cc:56
+ * \param args List of input tensors
+ * \return new symbol
+ */
+inline Symbol ElementWiseSum(const std::vector<Symbol>& args) {
+  return Operator("ElementWiseSum")
+(args)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Negate src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:52
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol negative(Symbol data) {
+  return Operator("negative")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take absolute value of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:58
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol abs(Symbol data) {
+  return Operator("abs")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take sign of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:67
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol sign(Symbol data) {
+  return Operator("sign")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take round of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:76
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol round(Symbol data) {
+  return Operator("round")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take ceil of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:81
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol ceil(Symbol data) {
+  return Operator("ceil")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take floor of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:86
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol floor(Symbol data) {
+  return Operator("floor")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take round of the src to nearest integer
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:91
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol rint(Symbol data) {
+  return Operator("rint")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take round of the src to integer nearest 0
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:96
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol fix(Symbol data) {
+  return Operator("fix")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take square of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:101
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol square(Symbol data) {
+  return Operator("square")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take square root of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:110
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol sqrt(Symbol data) {
+  return Operator("sqrt")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take reciprocal square root of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:119
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol rsqrt(Symbol data) {
+  return Operator("rsqrt")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take exp of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:129
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol exp(Symbol data) {
+  return Operator("exp")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take log of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:135
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol log(Symbol data) {
+  return Operator("log")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take base-10 log of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:141
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol log10(Symbol data) {
+  return Operator("log10")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take base-2 log of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:147
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol log2(Symbol data) {
+  return Operator("log2")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take sin of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:156
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol sin(Symbol data) {
+  return Operator("sin")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take `log(1 + x)` in a numerically stable way
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:165
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol log1p(Symbol data) {
+  return Operator("log1p")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take `exp(x) - 1` in a numerically stable way
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:174
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol expm1(Symbol data) {
+  return Operator("expm1")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take cos of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:183
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol cos(Symbol data) {
+  return Operator("cos")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take tan of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:192
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol tan(Symbol data) {
+  return Operator("tan")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take arcsin of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:201
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol arcsin(Symbol data) {
+  return Operator("arcsin")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take arccos of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:210
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol arccos(Symbol data) {
+  return Operator("arccos")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take arctan of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:219
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol arctan(Symbol data) {
+  return Operator("arctan")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take degrees of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:228
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol degrees(Symbol data) {
+  return Operator("degrees")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take radians of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:237
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol radians(Symbol data) {
+  return Operator("radians")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take sinh of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:246
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol sinh(Symbol data) {
+  return Operator("sinh")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take cosh of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:255
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol cosh(Symbol data) {
+  return Operator("cosh")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take tanh of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:264
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol tanh(Symbol data) {
+  return Operator("tanh")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take arcsinh of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:273
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol arcsinh(Symbol data) {
+  return Operator("arcsinh")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take arccosh of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:282
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol arccosh(Symbol data) {
+  return Operator("arccosh")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take arctanh of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:291
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol arctanh(Symbol data) {
+  return Operator("arctanh")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take the gamma function (extension of the factorial function) of the
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:300
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol gamma(Symbol data) {
+  return Operator("gamma")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Take gammaln (log of the absolute value of gamma(x)) of the src
+ *
+ *        From:src/operator/tensor/elemwise_unary_op.cc:309
+ * \param data Source input
+ * \return new symbol
+ */
+inline Symbol gammaln(Symbol data) {
+  return Operator("gammaln")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Map integer index to vector representations (embeddings). Those
+ *        embeddings are learnable parameters. For a input of shape (d1, ...,
+ *        dK), the output shape is (d1, ..., dK, output_dim). All the input
+ *
+ *        From:src/operator/tensor/indexing_op.cc:17
+ * \param data Input data to the EmbeddingOp.
+ * \param weight Embedding weight matrix.
+ * \param input_dim vocabulary size of the input indices.
+ * \param output_dim dimension of the embedding vectors.
+ * \return new symbol
+ */
+inline Symbol Embedding(Symbol data,
+                        Symbol weight,
+                        int input_dim,
+                        int output_dim) {
+  return Operator("Embedding")
+           .SetParam("input_dim", input_dim)
+           .SetParam("output_dim", output_dim)
+           .SetInput("data", data)
+           .SetInput("weight", weight)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Reshape input according to a target shape spec.
+ *        The target shape is a tuple and can be a simple list of dimensions
+ *        such as (12,3) or it can incorporate special codes that correspond
+ *        The special codes are all expressed as integers less than 1. These
+ *        codes effectively refer to a machine that pops input dims off the
+ *        beginning of the input dims list and pushes resulting output dims
+ *        onto the end of the output dims list, which starts empty. The codes
+ *        0  Copy     Pop one input dim and push it onto the output dims
+ *        -1  Infer    Push a dim that is inferred later from all other output
+ *        -2  CopyAll  Pop all remaining input dims and push them onto output
+ *        -3  Merge2   Pop two input dims, multiply them, and push result
+ *        -4  Split2   Pop one input dim, and read two next target shape specs,
+ *        push them both onto output dims (either can be -1 and will
+ *        be inferred from the other
+ *        The exact mathematical behavior of these codes is given in the
+ *        description of the 'shape' parameter. All non-codes (positive
+ *        integers) just pop a dim off the input dims (if any), throw it away,
+ *        Examples:
+ *        Type     Input      Target            Output
+ *        Copy     (2,3,4)    (4,0,2)           (4,3,2)
+ *        Copy     (2,3,4)    (2,0,0)           (2,3,4)
+ *        Infer    (2,3,4)    (6,1,-1)          (6,1,4)
+ *        Infer    (2,3,4)    (3,-1,8)          (3,1,8)
+ *        CopyAll  (9,8,7)    (-2)              (9,8,7)
+ *        CopyAll  (9,8,7)    (9,-2)            (9,8,7)
+ *        CopyAll  (9,8,7)    (-2,1,1)          (9,8,7,1,1)
+ *        Merge2   (3,4)      (-3)              (12)
+ *        Merge2   (3,4,5)    (-3,0)            (12,5)
+ *        Merge2   (3,4,5)    (0,-3)            (3,20)
+ *        Merge2   (3,4,5,6)  (-3,0,0)          (12,5,6)
+ *        Merge2   (3,4,5,6)  (-3,-2)           (12,5,6)
+ *        Split2   (12)       (-4,6,2)          (6,2)
+ *        Split2   (12)       (-4,2,6)          (2,6)
+ *        Split2   (12)       (-4,-1,6)         (2,6)
+ *        Split2   (12,9)     (-4,2,6,0)        (2,6,9)
+ *        Split2   (12,9,9,9) (-4,2,6,-2)       (2,6,9,9,9)
+ *        Split2   (12,12)    (-4,2,-1,-4,-1,2) (2,6,6,2)
+ *
+ *
+ *        From:src/operator/tensor/matrix_op.cc:61
+ * \param data Input data to reshape.
+ * \param target_shape (Deprecated! Use shape instead.) Target new shape. One
+ *        and only one dim can be 0, in which case it will be inferred from
+ * \param keep_highest (Deprecated! Use shape instead.) Whether keep the
+ *        highest dim unchanged.If set to true, then the first dim in
+ * \param shape Target shape, a tuple, t=(t_1,t_2,..,t_m).
+ *        Let the input dims be s=(s_1,s_2,..,s_n).
+ *        The output dims u=(u_1,u_2,..,u_p) are computed from s and t.
+ *        The target shape tuple elements t_i are read in order, and used to
+ *        t_i:       meaning:      behavior:
+ *        +ve        explicit      u_p = t_i
+ *        0          copy          u_p = s_i
+ *        -1         infer         u_p = (Prod s_i) / (Prod u_j | j != p)
+ *        -2         copy all      u_p = s_i, u_p+1 = s_i+1, ...
+ *        -3         merge two     u_p = s_i * s_i+1
+ *        -4,a,b     split two     u_p = a, u_p+1 = b | a * b = s_i
+ *        The split directive (-4) in the target shape tuple is followed by two
+ *        dimensions, one of which can be -1, which means it will be inferred
+ *        The can only be one globally inferred dimension (-1), aside from any
+ * \param reverse Whether to match the shapes from the backward. If reverse is
+ *        true, 0 values in the `shape` argument will be searched from the
+ *        backward. E.g the original shape is (10, 5, 4) and the shape
+ *        argument is (-1, 0). If reverse is true, the new shape should be
+ * \return new symbol
+ */
+inline Symbol Reshape(Symbol data,
+                      Shape target_shape = Shape(0,0),
+                      bool keep_highest = false,
+                      Shape shape = Shape(),
+                      bool reverse = false) {
+  return Operator("Reshape")
+           .SetParam("target_shape", target_shape)
+           .SetParam("keep_highest", keep_highest)
+           .SetParam("shape", shape)
+           .SetParam("reverse", reverse)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Flatten input into 2D by collapsing all the higher dimensions.
+ *        A (d1, d2, ..., dK) tensor is flatten to (d1, d2* ... *dK) matrix.
+ * \param data Input data to reshape.
+ * \return new symbol
+ */
+inline Symbol Flatten(Symbol data) {
+  return Operator("Flatten")
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Transpose the input tensor and return a new one
+ *
+ *        From:src/operator/tensor/matrix_op.cc:93
+ * \param data Source input
+ * \param axes Target axis order. By default the axes will be inverted.
+ * \return new symbol
+ */
+inline Symbol transpose(Symbol data,
+                        Shape axes = Shape()) {
+  return Operator("transpose")
+           .SetParam("axes", axes)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Expand the shape of array by inserting a new axis.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:121
+ * \param data Source input
+ * \param axis Position (amongst axes) where new axis is to be inserted.
+ * \return new symbol
+ */
+inline Symbol expand_dims(Symbol data,
+                          int axis) {
+  return Operator("expand_dims")
+           .SetParam("axis", axis)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif (Crop the input tensor and return a new one.
+ *
+ *        Requirements
+ *        ------------
+ *        - the input and output (if explicitly given) are of the same data
+ *        and on the same device.
+ *        )
+ *
+ *        From:src/operator/tensor/matrix_op.cc:142
+ * \param data Source input
+ * \param begin starting coordinates
+ * \param end ending coordinates
+ * \return new symbol
+ */
+inline Symbol crop(Symbol data,
+                   Shape begin,
+                   Shape end) {
+  return Operator("crop")
+           .SetParam("begin", begin)
+           .SetParam("end", end)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Slice the input along certain axis and return a sliced array.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:197
+ * \param data Source input
+ * \param axis The axis to be sliced
+ * \param begin The beginning index to be sliced
+ * \param end The end index to be sliced
+ * \return new symbol
+ */
+inline Symbol slice_axis(Symbol data,
+                         int axis,
+                         int begin,
+                         int end) {
+  return Operator("slice_axis")
+           .SetParam("axis", axis)
+           .SetParam("begin", begin)
+           .SetParam("end", end)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Flip the input tensor along axis and return a new one.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:216
+ * \param data Source input
+ * \param axis The dimension to flip
+ * \return new symbol
+ */
+inline Symbol flip(Symbol data,
+                   int axis) {
+  return Operator("flip")
+           .SetParam("axis", axis)
+           .SetInput("data", data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Calculate dot product of two matrices or two vectors.
+ *
+ *        From:src/operator/tensor/matrix_op.cc:228
+ * \param lhs Left input
+ * \param rhs Right input
+ * \param transpose_a True if the first matrix is transposed.
+ * \param transpose_b True if the second matrix is tranposed.
+ * \return new symbol
+ */
+inline Symbol dot(Symbol lhs,
+                  Symbol rhs,
+                  bool transpose_a = false,
+                  bool transpose_b = false) {
+  return Operator("dot")
+           .SetParam("transpose_a", transpose_a)
+           .SetParam("transpose_b", transpose_b)
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Calculate batched dot product of two matrices. (batch, M, K)
+ *
+ *        From:src/operator/tensor/matrix_op.cc:254
+ * \param lhs Left input
+ * \param rhs Right input
+ * \param axis The dimension to flip
+ * \return new symbol
+ */
+inline Symbol batch_dot(Symbol lhs,
+                        Symbol rhs,
+                        int axis) {
+  return Operator("batch_dot")
+           .SetParam("axis", axis)
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Sample a uniform distribution
+ * \param low The lower bound of distribution
+ * \param high The upper bound of distribution
+ * \param shape The shape of the output
+ * \param ctx Context of output, in format [cpu|gpu|cpu_pinned](n).Only used
+ * \return new symbol
+ */
+inline Symbol uniform(mx_float low = 0,
+                      mx_float high = 1,
+                      Shape shape = Shape(),
+                      const std::string& ctx = "") {
+  return Operator("uniform")
+           .SetParam("low", low)
+           .SetParam("high", high)
+           .SetParam("shape", shape)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Sample a normal distribution
+ * \param loc Mean of the distribution.
+ * \param scale Standard deviation of the distribution.
+ * \param shape The shape of the output
+ * \param ctx Context of output, in format [cpu|gpu|cpu_pinned](n).Only used
+ * \return new symbol
+ */
+inline Symbol normal(mx_float loc = 0,
+                     mx_float scale = 1,
+                     Shape shape = Shape(),
+                     const std::string& ctx = "") {
+  return Operator("normal")
+           .SetParam("loc", loc)
+           .SetParam("scale", scale)
+           .SetParam("shape", shape)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Calculate cross_entropy(lhs, one_hot(rhs))
+ *
+ *        From:src/operator/loss_binary_op.cc:12
+ * \param data Input data
+ * \param label Input label
+ * \return new symbol
+ */
+inline Symbol softmax_cross_entropy(Symbol data,
+                                    Symbol label) {
+  return Operator("softmax_cross_entropy")
+           .SetInput("data", data)
+           .SetInput("label", label)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Updater function for sgd optimizer
+ * \return new symbol
+ */
+inline Symbol sgd_update() {
+  return Operator("sgd_update")
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Updater function for sgd optimizer
+ * \return new symbol
+ */
+inline Symbol sgd_mom_update() {
+  return Operator("sgd_mom_update")
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Updater function for adam optimizer
+ * \return new symbol
+ */
+inline Symbol adam_update() {
+  return Operator("adam_update")
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Elementwise activation function.
+ *
+ *        The following activation types are supported (operations are applied
+ *        scalar of the input tensor):
+ *
+ *        - `relu`: Rectified Linear Unit, `y = max(x, 0)`
+ *        - `sigmoid`: `y = 1 / (1 + exp(-x))`
+ *        - `tanh`: Hyperbolic tangent, `y = (exp(x) - exp(-x)) / (exp(x) +
+ *        - `softrelu`: Soft ReLU, or SoftPlus, `y = log(1 + exp(x))`
+ *
+ *        See `LeakyReLU` for other activations with parameters.
+ *
+ * \param data Input data to activation function.
+ * \param act_type Activation function to be applied.
  * \return new symbol
  */
 inline Symbol Activation(Symbol data,
@@ -1285,14 +3909,13 @@ inline Symbol Activation(Symbol data,
 }
 
 /*!
- * \breif Apply batch normalization to input. 
- * \param data Input data to batch normalization.
- * \param eps Epsilon to prevent div 0.
- * \param momentum Momentum for moving average.
- * \param fix_gamma Fix gamma while training.
+ * \breif Apply batch normalization to input.
+ * \param data Input data to batch normalization
+ * \param eps Epsilon to prevent div 0
+ * \param momentum Momentum for moving average
+ * \param fix_gamma Fix gamma while training
  * \param use_global_stats Whether use global moving statistics instead of
  *        local batch-norm. This will force change batch-norm into a scale
- *        shift operator.
  * \return new symbol
  */
 inline Symbol BatchNorm(Symbol data,
@@ -1310,8 +3933,8 @@ inline Symbol BatchNorm(Symbol data,
 }
 
 /*!
- * \breif Get output from a symbol and pass 0 gradient back.
- * \param data Input data. 
+ * \breif Get output from a symbol and pass 0 gradient back
+ * \param data Input data.
  * \return new symbol
  */
 inline Symbol BlockGrad(Symbol data) {
@@ -1321,56 +3944,9 @@ inline Symbol BlockGrad(Symbol data) {
 }
 
 /*!
- * \breif (Deprecated! Use sum_axis instead.
- *        ) Take sum of the src.The result will be ndarray of shape (1,) on the
- *        same device.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol sum(Symbol lhs,
-                  Symbol rhs) {
-  return Operator("sum")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Take sum of the src in the given axis.
- *        axis=-1 means to reduce all the dimensions.The keepdims option has
- *        the same meaning as Numpy.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol sum_axis(Symbol lhs,
-                       Symbol rhs) {
-  return Operator("sum_axis")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Broadcast data in the given axis to the given size.
- *        The original size of the broadcasting axis must be 1.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol broadcast_axis(Symbol lhs,
-                             Symbol rhs) {
-  return Operator("broadcast_axis")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Cast array to a different data type. 
- * \param data Input data to cast function. 
- * \param dtype Target data type. 
+ * \breif Cast array to a different data type.
+ * \param data Input data to cast function.
+ * \param dtype Target data type.
  * \return new symbol
  */
 inline Symbol Cast(Symbol data,
@@ -1389,10 +3965,10 @@ inline Symbol Cast(Symbol data,
 }
 
 /*!
- * \breif Perform an feature concat on channel dim (defaut is 1) over all.
- * \param data List of tensors to concatenate.
- * \param num_args Number of inputs to be concated. 
- * \param dim the dimension to be concated. 
+ * \breif Perform a feature concat on channel dim (defaut is 1) over all
+ * \param data List of tensors to concatenate
+ * \param num_args Number of inputs to be concated.
+ * \param dim the dimension to be concated.
  * \return new symbol
  */
 inline Symbol Concat(const std::vector<Symbol>& data,
@@ -1406,20 +3982,30 @@ inline Symbol Concat(const std::vector<Symbol>& data,
 }
 
 /*!
- * \breif Apply convolution to input then add a bias. 
- * \param data Input data to the ConvolutionOp. 
- * \param weight Weight matrix. 
- * \param bias Bias parameter. 
- * \param kernel convolution kernel size: (y, x).
- * \param num_filter convolution filter(channel) number.
- * \param stride convolution stride: (y, x).
- * \param dilate convolution dilate: (y, x).
- * \param pad pad for convolution: (y, x).
- * \param num_group Number of groups partition.
- *        This option is not supported by CuDNN, you can use SliceChannel to
- *        num_group,apply convolution and concat instead to achieve the same need.
- * \param workspace Tmp workspace for convolution (MB). 
- * \param no_bias Whether to disable bias parameter. 
+ * \breif Apply convolution to input then add a bias.
+ * \param data Input data to the ConvolutionOp.
+ * \param weight Weight matrix.
+ * \param bias Bias parameter.
+ * \param kernel convolution kernel size: (h, w) or (d, h, w)
+ * \param num_filter convolution filter(channel) number
+ * \param stride convolution stride: (h, w) or (d, h, w)
+ * \param dilate convolution dilate: (h, w) or (d, h, w)
+ * \param pad pad for convolution: (h, w) or (d, h, w)
+ * \param num_group Number of group partitions. Equivalent to slicing input
+ *        partitions, apply convolution on each, then concatenate the results
+ * \param workspace Maximum tmp workspace allowed for convolution (MB).
+ * \param no_bias Whether to disable bias parameter.
+ * \param cudnn_tune Whether to pick convolution algo by running performance
+ *        Leads to higher startup time but may give faster speed. Options are:
+ *        'off': no tuning
+ *        'limited_workspace': run test and pick the fastest algorithm that
+ *        'fastest': pick the fastest algorithm and ignore workspace limit.
+ *        If set to None (default), behavior is determined by environment
+ *        variable MXNET_CUDNN_AUTOTUNE_DEFAULT: 0 for off,
+ *        1 for limited workspace (default), 2 for fastest.
+ * \param cudnn_off Turn off cudnn for this layer.
+ * \param layout Set layout for input, output and weight. Empty for
+ *        default layout: NCHW for 2d and NCDHW for 3d.
  * \return new symbol
  */
 inline Symbol Convolution(Symbol data,
@@ -1427,12 +4013,28 @@ inline Symbol Convolution(Symbol data,
                           Symbol bias,
                           Shape kernel,
                           int num_filter,
-                          Shape stride = Shape(1,1),
-                          Shape dilate = Shape(1,1),
-                          Shape pad = Shape(0,0),
+                          Shape stride = Shape(),
+                          Shape dilate = Shape(),
+                          Shape pad = Shape(),
                           int num_group = 1,
-                          int64_t workspace = 512,
-                          bool no_bias = false) {
+                          int64_t workspace = 1024,
+                          bool no_bias = false,
+                          ConvolutionCudnnTune cudnn_tune = ConvolutionCudnnTune::None,
+                          bool cudnn_off = false,
+                          ConvolutionLayout layout = ConvolutionLayout::None) {
+  static const char *ConvolutionCudnnTuneValues[] = {
+    "None",
+    "fastest",
+    "limited_workspace",
+    "off"
+  };
+  static const char *ConvolutionLayoutValues[] = {
+    "None",
+    "NCDHW",
+    "NCHW",
+    "NDHWC",
+    "NHWC"
+  };
   return Operator("Convolution")
            .SetParam("kernel", kernel)
            .SetParam("num_filter", num_filter)
@@ -1442,6 +4044,9 @@ inline Symbol Convolution(Symbol data,
            .SetParam("num_group", num_group)
            .SetParam("workspace", workspace)
            .SetParam("no_bias", no_bias)
+           .SetParam("cudnn_tune", ConvolutionCudnnTuneValues[int(cudnn_tune)])
+           .SetParam("cudnn_off", cudnn_off)
+           .SetParam("layout", ConvolutionLayoutValues[int(layout)])
            .SetInput("data", data)
            .SetInput("weight", weight)
            .SetInput("bias", bias)
@@ -1449,19 +4054,48 @@ inline Symbol Convolution(Symbol data,
 }
 
 /*!
+ * \breif Apply correlation to inputs
+ * \param data1 Input data1 to the correlation.
+ * \param data2 Input data2 to the correlation.
+ * \param kernel_size kernel size for Correlation must be an odd number
+ * \param max_displacement Max displacement of Correlation
+ * \param stride1 stride1 quantize data1 globally
+ * \param stride2 stride2 quantize data2 within the neighborhood centered
+ * \param pad_size pad for Correlation
+ * \param is_multiply operation type is either multiplication or subduction
+ * \return new symbol
+ */
+inline Symbol Correlation(Symbol data1,
+                          Symbol data2,
+                          int kernel_size = 1,
+                          int max_displacement = 1,
+                          int stride1 = 1,
+                          int stride2 = 1,
+                          int pad_size = 0,
+                          bool is_multiply = true) {
+  return Operator("Correlation")
+           .SetParam("kernel_size", kernel_size)
+           .SetParam("max_displacement", max_displacement)
+           .SetParam("stride1", stride1)
+           .SetParam("stride2", stride2)
+           .SetParam("pad_size", pad_size)
+           .SetParam("is_multiply", is_multiply)
+           .SetInput("data1", data1)
+           .SetInput("data2", data2)
+           .CreateSymbol();
+}
+
+/*!
  * \breif Crop the 2nd and 3rd dim of input data, with the corresponding size
  *        of h_w or with width and height of the second input symbol, i.e.,
  *        with one input, we need h_w to specify the crop height and width,
- *        otherwise the second input symbol's size will be used
  * \param data Tensor or List of Tensors, the second input will be used as
- *        crop_like shape reference
  * \param num_args Number of inputs for crop, if equals one, then we will use
  *        the h_wfor crop height and width, else if equals two, then we will
- *        use the heightand width of the second input symbol, we name crop_like here
- * \param offset crop offset coordinate: (y, x).
- * \param h_w crop height and weight: (h, w).
+ *        use the heightand width of the second input symbol, we name
+ * \param offset crop offset coordinate: (y, x)
+ * \param h_w crop height and weight: (h, w)
  * \param center_crop If set to true, then it will use be the center_crop,or it
- *        will crop using the shape of crop_like
  * \return new symbol
  */
 inline Symbol Crop(Symbol data,
@@ -1479,9 +4113,8 @@ inline Symbol Crop(Symbol data,
 }
 
 /*!
- * \breif Custom operator implemented in frontend. 
- * \param op_type Type of custom operator.
- *        Must be registered first.
+ * \breif Custom operator implemented in frontend.
+ * \param op_type Type of custom operator. Must be registered first.
  * \return new symbol
  */
 inline Symbol Custom(const std::string& op_type) {
@@ -1490,17 +4123,20 @@ inline Symbol Custom(const std::string& op_type) {
 }
 
 /*!
- * \breif Apply deconvolution to input then add a bias. 
- * \param data Input data to the DeconvolutionOp. 
- * \param weight Weight matrix. 
- * \param bias Bias parameter. 
- * \param kernel deconvolution kernel size: (y, x).
- * \param num_filter deconvolution filter(channel) number.
- * \param stride deconvolution stride: (y, x).
- * \param pad pad for deconvolution: (y, x).
- * \param num_group number of groups partition.
- * \param workspace Tmp workspace for deconvolution (MB).
- * \param no_bias Whether to disable bias parameter. 
+ * \breif Apply deconvolution to input then add a bias.
+ * \param data Input data to the DeconvolutionOp.
+ * \param weight Weight matrix.
+ * \param bias Bias parameter.
+ * \param kernel deconvolution kernel size: (y, x)
+ * \param num_filter deconvolution filter(channel) number
+ * \param stride deconvolution stride: (y, x)
+ * \param pad pad for deconvolution: (y, x), a good number is : (kernel-1)/2,
+ *        if target_shape set, pad will be ignored and will be computed
+ * \param adj adjustment for output shape: (y, x), if target_shape set, adj
+ * \param target_shape output shape with targe shape : (y, x)
+ * \param num_group number of groups partition
+ * \param workspace Tmp workspace for deconvolution (MB)
+ * \param no_bias Whether to disable bias parameter.
  * \return new symbol
  */
 inline Symbol Deconvolution(Symbol data,
@@ -1510,6 +4146,8 @@ inline Symbol Deconvolution(Symbol data,
                             int num_filter,
                             Shape stride = Shape(1,1),
                             Shape pad = Shape(0,0),
+                            Shape adj = Shape(0,0),
+                            Shape target_shape = Shape(0,0),
                             int num_group = 1,
                             int64_t workspace = 512,
                             bool no_bias = true) {
@@ -1518,6 +4156,8 @@ inline Symbol Deconvolution(Symbol data,
            .SetParam("num_filter", num_filter)
            .SetParam("stride", stride)
            .SetParam("pad", pad)
+           .SetParam("adj", adj)
+           .SetParam("target_shape", target_shape)
            .SetParam("num_group", num_group)
            .SetParam("workspace", workspace)
            .SetParam("no_bias", no_bias)
@@ -1529,8 +4169,12 @@ inline Symbol Deconvolution(Symbol data,
 
 /*!
  * \breif Apply dropout to input.
- * \param data Input data to dropout. 
- * \param p Fraction of the input that gets dropped out at training time.
+ *        During training, each element of the input is randomly set to zero
+ *        And then the whole tensor is rescaled by 1/(1-p) to keep the
+ *        before applying dropout. During the test time, this behaves as an
+ *
+ * \param data Input data to dropout.
+ * \param p Fraction of the input that gets dropped out at training time
  * \return new symbol
  */
 inline Symbol Dropout(Symbol data,
@@ -1542,270 +4186,15 @@ inline Symbol Dropout(Symbol data,
 }
 
 /*!
- * \breif lhs add rhs with broadcast.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol broadcast_plus(Symbol lhs,
-                             Symbol rhs) {
-  return Operator("broadcast_plus")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif lhs minus rhs with broadcast.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol broadcast_minus(Symbol lhs,
-                              Symbol rhs) {
-  return Operator("broadcast_minus")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif lhs multiple rhs with broadcast.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol broadcast_mul(Symbol lhs,
-                            Symbol rhs) {
-  return Operator("broadcast_mul")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif lhs divide rhs with broadcast.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol broadcast_div(Symbol lhs,
-                            Symbol rhs) {
-  return Operator("broadcast_div")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Perform an elementwise sum over all the inputs. 
- * \param num_args Number of inputs to be summed. 
- * \return new symbol
- */
-inline Symbol ElementWiseSum(int num_args) {
-  return Operator("ElementWiseSum")
-           .SetParam("num_args", num_args)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Take absolute value of the src.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol abs(Symbol lhs,
-                  Symbol rhs) {
-  return Operator("abs")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Take sign value of the src.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol sign(Symbol lhs,
-                   Symbol rhs) {
-  return Operator("sign")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Take round value of the src.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol round(Symbol lhs,
-                    Symbol rhs) {
-  return Operator("round")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Take ceil value of the src.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol ceil(Symbol lhs,
-                   Symbol rhs) {
-  return Operator("ceil")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Take floor value of the src.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol floor(Symbol lhs,
-                    Symbol rhs) {
-  return Operator("floor")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Take square of the src.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol square(Symbol lhs,
-                     Symbol rhs) {
-  return Operator("square")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Take sqrt of the src.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol sqrt(Symbol lhs,
-                   Symbol rhs) {
-  return Operator("sqrt")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Take rsqrt of the src.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol rsqrt(Symbol lhs,
-                    Symbol rhs) {
-  return Operator("rsqrt")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Take exp of the src.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol exp(Symbol lhs,
-                  Symbol rhs) {
-  return Operator("exp")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Take log of the src.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol log(Symbol lhs,
-                  Symbol rhs) {
-  return Operator("log")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Take cos of the src.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol cos(Symbol lhs,
-                  Symbol rhs) {
-  return Operator("cos")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Take sin of the src.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol sin(Symbol lhs,
-                  Symbol rhs) {
-  return Operator("sin")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Get embedding for one-hot input.
- *        A n-dimensional input tensor will be trainsformed into a
- *        (n+1)-dimensional tensor, where a new dimension is added for the
- *        embedding results.
- * \param data Input data to the EmbeddingOp. 
- * \param weight Enbedding weight matrix. 
- * \param input_dim input dim of one-hot encoding.
- * \param output_dim output dim of embedding.
- * \return new symbol
- */
-inline Symbol Embedding(Symbol data,
-                        Symbol weight,
-                        int input_dim,
-                        int output_dim) {
-  return Operator("Embedding")
-           .SetParam("input_dim", input_dim)
-           .SetParam("output_dim", output_dim)
-           .SetInput("data", data)
-           .SetInput("weight", weight)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Apply matrix multiplication to input then add a bias. 
- * \param data Input data to the FullyConnectedOp. 
- * \param weight Weight matrix. 
- * \param bias Bias parameter. 
- * \param num_hidden Number of hidden nodes of the output. 
- * \param no_bias Whether to disable bias parameter. 
+ * \breif Apply matrix multiplication to input then add a bias.
+ *        It maps the input of shape `(batch_size, input_dim)` to the shape of
+ *        `(batch_size, num_hidden)`. Learnable parameters include the weights
+ *        of the linear transform and an optional bias vector.
+ * \param data Input data to the FullyConnectedOp.
+ * \param weight Weight matrix.
+ * \param bias Bias parameter.
+ * \param num_hidden Number of hidden nodes of the output.
+ * \param no_bias Whether to disable bias parameter.
  * \return new symbol
  */
 inline Symbol FullyConnected(Symbol data,
@@ -1823,11 +4212,11 @@ inline Symbol FullyConnected(Symbol data,
 }
 
 /*!
- * \breif Apply a sparse regularization to the output a sigmoid activation function. 
- * \param data Input data. 
- * \param sparseness_target The sparseness target.
- * \param penalty The tradeoff parameter for the sparseness penalty.
- * \param momentum The momentum for running average.
+ * \breif Apply a sparse regularization to the output a sigmoid activation
+ * \param data Input data.
+ * \param sparseness_target The sparseness target
+ * \param penalty The tradeoff parameter for the sparseness penalty
+ * \param momentum The momentum for running average
  * \return new symbol
  */
 inline Symbol IdentityAttachKLSparseReg(Symbol data,
@@ -1843,29 +4232,65 @@ inline Symbol IdentityAttachKLSparseReg(Symbol data,
 }
 
 /*!
- * \breif Set the l2 norm of each instance to a constant. 
- * \param data Input data to the L2NormalizationOp. 
- * \param eps Epsilon to prevent div 0.
+ * \breif An operator taking in a n-dimensional input tensor (n > 2), and
+ *        normalizing the input by subtracting the mean and variance
+ *        calculated over the spatial dimensions. This is an implemention of
+ *        the operator described in "Instance Normalization: The Missing
+ *        Ingredient for Fast Stylization", D. Ulyanov, A. Vedaldi, V.
+ *        Lempitsky, 2016 (arXiv:1607.08022v2). This layer is similar to batch
+ *        normalization, with two differences: first, the normalization is
+ *        carried out per example ('instance'), not over a batch. Second, the
+ *        same normalization is applied both at test and train time. This
+ * \param data A n-dimensional tensor (n > 2) of the form [batch, channel,
+ * \param gamma A vector of length 'channel', which multiplies the normalized
+ * \param beta A vector of length 'channel', which is added to the product of
+ * \param eps Epsilon to prevent division by 0.
+ * \return new symbol
+ */
+inline Symbol InstanceNorm(Symbol data,
+                           Symbol gamma,
+                           Symbol beta,
+                           mx_float eps = 0.001) {
+  return Operator("InstanceNorm")
+           .SetParam("eps", eps)
+           .SetInput("data", data)
+           .SetInput("gamma", gamma)
+           .SetInput("beta", beta)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Set the l2 norm of each instance to a constant.
+ * \param data Input data to the L2NormalizationOp.
+ * \param eps Epsilon to prevent div 0
+ * \param mode Normalization Mode. If set to instance, this operator will
+ *        compute a norm for each instance in the batch; this is the default
+ *        mode. If set to channel, this operator will compute a cross channel
+ *        norm at each position of each instance. If set to spatial, this
  * \return new symbol
  */
 inline Symbol L2Normalization(Symbol data,
-                              mx_float eps = 1e-010) {
+                              mx_float eps = 1e-10,
+                              L2NormalizationMode mode = L2NormalizationMode::instance) {
+  static const char *L2NormalizationModeValues[] = {
+    "channel",
+    "instance",
+    "spatial"
+  };
   return Operator("L2Normalization")
            .SetParam("eps", eps)
+           .SetParam("mode", L2NormalizationModeValues[int(mode)])
            .SetInput("data", data)
            .CreateSymbol();
 }
 
 /*!
- * \breif Apply activation function to input. 
- * \param data Input data to activation function. 
- * \param act_type Activation function to be applied. 
- * \param slope Init slope for the activation.
- *        (For leaky and elu only)
- * \param lower_bound Lower bound of random slope.
- *        (For rrelu only)
- * \param upper_bound Upper bound of random slope.
- *        (For rrelu only)
+ * \breif Apply activation function to input.
+ * \param data Input data to activation function.
+ * \param act_type Activation function to be applied.
+ * \param slope Init slope for the activation. (For leaky and elu only)
+ * \param lower_bound Lower bound of random slope. (For rrelu only)
+ * \param upper_bound Upper bound of random slope. (For rrelu only)
  * \return new symbol
  */
 inline Symbol LeakyReLU(Symbol data,
@@ -1889,27 +4314,12 @@ inline Symbol LeakyReLU(Symbol data,
 }
 
 /*!
- * \breif Calculate cross_entropy(lhs, one_hot(rhs)).
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol softmax_cross_entropy(Symbol lhs,
-                                    Symbol rhs) {
-  return Operator("softmax_cross_entropy")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Apply convolution to input then add a bias. 
- * \param data Input data to the ConvolutionOp. 
- * \param nsize normalization window width in elements. 
+ * \breif Apply convolution to input then add a bias.
+ * \param data Input data to the ConvolutionOp.
+ * \param nsize normalization window width in elements.
  * \param alpha value of the alpha variance scaling parameter in the
- *        normalization formula
- * \param beta value of the beta power parameter in the normalization formula.
- * \param knorm value of the k parameter in normalization formula.
+ * \param beta value of the beta power parameter in the normalization formula
+ * \param knorm value of the k parameter in normalization formula
  * \return new symbol
  */
 inline Symbol LRN(Symbol data,
@@ -1927,64 +4337,80 @@ inline Symbol LRN(Symbol data,
 }
 
 /*!
- * \breif Get output from a symbol and pass 1 gradient back.
- *        This is used as a terminal loss if unary and binary operator are used
- *        to composite a loss with no declaration of backward dependency
- * \param data Input data. 
- * \param grad_scale gradient scale as a supplement to unary and binary operators.
+ * \breif Get output from a symbol and pass 1 gradient back. This is used as a
+ *        terminal loss if unary and binary operator are used to composite a
+ * \param data Input data.
+ * \param grad_scale gradient scale as a supplement to unary and binary
+ * \param valid_thresh regard element valid when x > valid_thresh, this is used
+ * \param normalization If set to null, op will not normalize on output
+ *        gradient.If set to batch, op will normalize gradient by divide batch
+ *        size.If set to valid, op will normalize gradient by divide # sample
  * \return new symbol
  */
 inline Symbol MakeLoss(Symbol data,
-                       mx_float grad_scale = 1) {
+                       mx_float grad_scale = 1,
+                       mx_float valid_thresh = 0,
+                       MakeLossNormalization normalization = MakeLossNormalization::null) {
+  static const char *MakeLossNormalizationValues[] = {
+    "batch",
+    "null",
+    "valid"
+  };
   return Operator("MakeLoss")
            .SetParam("grad_scale", grad_scale)
+           .SetParam("valid_thresh", valid_thresh)
+           .SetParam("normalization", MakeLossNormalizationValues[int(normalization)])
            .SetInput("data", data)
            .CreateSymbol();
 }
 
 /*!
- * \breif Transpose the input matrix and return a new one.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
+ * \breif Pads an n-dimensional input tensor. Allows for precise control of the
+ *        padding type and how much padding to apply on both sides of a given
+ * \param data An n-dimensional input tensor.
+ * \param mode Padding type to use. "constant" pads all values with a constant
+ *        value, the value of which can be specified with the constant_value
+ * \param pad_width A tuple of padding widths of length 2*r, where r is the
+ *        rank of the input tensor, specifying number of values padded to the
+ *        edges of each axis. (before_1, after_1, ... , before_N, after_N)
+ *        unique pad widths for each axis. Equivalent to pad_width in
+ * \param constant_value This option is only used when mode is "constant". This
+ *        value will be used as the padding value. Defaults to 0 if not
  * \return new symbol
  */
-inline Symbol transpose(Symbol lhs,
-                        Symbol rhs) {
-  return Operator("transpose")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
+inline Symbol Pad(Symbol data,
+                  PadMode mode,
+                  Shape pad_width,
+                  double constant_value = 0) {
+  static const char *PadModeValues[] = {
+    "constant",
+    "edge"
+  };
+  return Operator("Pad")
+           .SetParam("mode", PadModeValues[int(mode)])
+           .SetParam("pad_width", pad_width)
+           .SetParam("constant_value", constant_value)
+           .SetInput("data", data)
            .CreateSymbol();
 }
 
 /*!
- * \breif Calculate dot product of two matrices or two vectors.
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol dot(Symbol lhs,
-                  Symbol rhs) {
-  return Operator("dot")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Perform spatial pooling on inputs. 
- * \param data Input data to the pooling operator. 
- * \param kernel pooling kernel size: (y, x).
- * \param pool_type Pooling type to be applied. 
+ * \breif Perform spatial pooling on inputs.
+ * \param data Input data to the pooling operator.
+ * \param kernel pooling kernel size: (y, x) or (d, y, x)
+ * \param pool_type Pooling type to be applied.
  * \param global_pool Ignore kernel size, do global pooling based on current
- *        input feature map. This is useful for input with different shape
- * \param stride stride: for pooling (y, x).
- * \param pad pad for pooling: (y, x).
+ * \param pooling_convention Pooling convention to be applied.kValid is default
+ *        setting of Mxnet and rounds down the output pooling size.kFull is
+ * \param stride stride: for pooling (y, x) or (d, y, x)
+ * \param pad pad for pooling: (y, x) or (d, y, x)
  * \return new symbol
  */
 inline Symbol Pooling(Symbol data,
                       Shape kernel,
                       PoolingPoolType pool_type,
                       bool global_pool = false,
+                      PoolingPoolingConvention pooling_convention = PoolingPoolingConvention::valid,
                       Shape stride = Shape(1,1),
                       Shape pad = Shape(0,0)) {
   static const char *PoolingPoolTypeValues[] = {
@@ -1992,10 +4418,15 @@ inline Symbol Pooling(Symbol data,
     "max",
     "sum"
   };
+  static const char *PoolingPoolingConventionValues[] = {
+    "full",
+    "valid"
+  };
   return Operator("Pooling")
            .SetParam("kernel", kernel)
            .SetParam("pool_type", PoolingPoolTypeValues[int(pool_type)])
            .SetParam("global_pool", global_pool)
+           .SetParam("pooling_convention", PoolingPoolingConventionValues[int(pooling_convention)])
            .SetParam("stride", stride)
            .SetParam("pad", pad)
            .SetInput("data", data)
@@ -2003,10 +4434,10 @@ inline Symbol Pooling(Symbol data,
 }
 
 /*!
- * \breif Use linear regression for final output, this is used on final output of a net. 
- * \param data Input data to function. 
- * \param label Input label to function. 
- * \param grad_scale Scale the gradient by a float factor.
+ * \breif Use linear regression for final output, this is used on final output
+ * \param data Input data to function.
+ * \param label Input label to function.
+ * \param grad_scale Scale the gradient by a float factor
  * \return new symbol
  */
 inline Symbol LinearRegressionOutput(Symbol data,
@@ -2021,10 +4452,9 @@ inline Symbol LinearRegressionOutput(Symbol data,
 
 /*!
  * \breif Use mean absolute error regression for final output, this is used on
- *        final output of a net.
- * \param data Input data to function. 
- * \param label Input label to function. 
- * \param grad_scale Scale the gradient by a float factor.
+ * \param data Input data to function.
+ * \param label Input label to function.
+ * \param grad_scale Scale the gradient by a float factor
  * \return new symbol
  */
 inline Symbol MAERegressionOutput(Symbol data,
@@ -2038,12 +4468,11 @@ inline Symbol MAERegressionOutput(Symbol data,
 }
 
 /*!
- * \breif Use Logistic regression for final output, this is used on final output of a net.
+ * \breif Use Logistic regression for final output, this is used on final
  *        Logistic regression is suitable for binary classification or
- *        probability prediction tasks.
- * \param data Input data to function. 
- * \param label Input label to function. 
- * \param grad_scale Scale the gradient by a float factor.
+ * \param data Input data to function.
+ * \param label Input label to function.
+ * \param grad_scale Scale the gradient by a float factor
  * \return new symbol
  */
 inline Symbol LogisticRegressionOutput(Symbol data,
@@ -2057,52 +4486,61 @@ inline Symbol LogisticRegressionOutput(Symbol data,
 }
 
 /*!
- * \breif Reshape input to target shape.
- * \param data Input data to reshape. 
- * \param target_shape (Deprecated! Use shape instead.
- *        ) Target new shape. One and only one dim can be 0, in which case it
- *        will be inferred from the rest of dims
- * \param keep_highest (Deprecated! Use shape instead.
- *        ) Whether keep the highest dim unchanged.If set to yes, than the
- *        first dim in target_shape is ignored,and always fixed as input
- * \param shape Target new shape.
- *        If the dim is same, set it to 0. If the dim is set to be -1, it will
- *        be inferred from the rest of dims. One and only one dim can be -1
+ * \breif Apply a recurrent layer to input.
+ * \param data Input data to RNN
+ * \param parameters Vector of all RNN trainable parameters concatenated
+ * \param state initial hidden state of the RNN
+ * \param state_cell initial cell state for LSTM networks (only for LSTM)
+ * \param state_size size of the state for each layer
+ * \param num_layers number of stacked layers
+ * \param mode the type of RNN to compute
+ * \param bidirectional whether to use bidirectional recurrent layers
+ * \param p Dropout probability, fraction of the input that gets dropped out at
+ * \param state_outputs Whether to have the states as symbol outputs.
  * \return new symbol
  */
-inline Symbol Reshape(Symbol data,
-                      Shape shape = Shape()) {
-  return Operator("Reshape")
-           .SetParam("shape", shape)
+inline Symbol RNN(Symbol data,
+                  Symbol parameters,
+                  Symbol state,
+                  Symbol state_cell,
+                  int state_size,
+                  int num_layers,
+                  RNNMode mode,
+                  bool bidirectional = false,
+                  mx_float p = 0,
+                  bool state_outputs = false) {
+  static const char *RNNModeValues[] = {
+    "gru",
+    "lstm",
+    "rnn_relu",
+    "rnn_tanh"
+  };
+  return Operator("RNN")
+           .SetParam("state_size", state_size)
+           .SetParam("num_layers", num_layers)
+           .SetParam("mode", RNNModeValues[int(mode)])
+           .SetParam("bidirectional", bidirectional)
+           .SetParam("p", p)
+           .SetParam("state_outputs", state_outputs)
            .SetInput("data", data)
+           .SetInput("parameters", parameters)
+           .SetInput("state", state)
+           .SetInput("state_cell", state_cell)
            .CreateSymbol();
 }
 
 /*!
- * \breif Flatten input.
- * \param data Input data to flatten. 
- * \return new symbol
- */
-inline Symbol Flatten(Symbol data) {
-  return Operator("Flatten")
-           .SetInput("data", data)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Performs region-of-interest pooling on inputs.
- *        Resize bounding box coordinates by spatial_scale and crop input
- *        feature maps accordingly. The cropped feature maps are pooled by max
- *        pooling to a fixed size output indicated by pooled_size. batch_size
- *        will change to the number of region bounding boxes after ROIPooling
- * \param data Input data to the pooling operator, a 4D Feature maps.
- * \param rois Bounding box coordinates, a 2D array of [[batch_index, x1, y1, x2, y2]].
- *        (x1, y1) and (x2, y2) are top left and down right corners of
- *        designated region of interest. batch_index indicates the index of
- *        corresponding image in the input data
- * \param pooled_size fix pooled size: (h, w).
+ * \breif Performs region-of-interest pooling on inputs. Resize bounding box
+ *        coordinates by spatial_scale and crop input feature maps
+ *        accordingly. The cropped feature maps are pooled by max pooling to a
+ *        fixed size output indicated by pooled_size. batch_size will change
+ * \param data Input data to the pooling operator, a 4D Feature maps
+ * \param rois Bounding box coordinates, a 2D array of [[batch_index, x1, y1,
+ *        x2, y2]]. (x1, y1) and (x2, y2) are top left and down right corners
+ *        of designated region of interest. batch_index indicates the index of
+ * \param pooled_size fix pooled size: (h, w)
  * \param spatial_scale Ratio of input feature map height (or w) to raw image
- *        height (or w). Equals the reciprocal of total stride in convolutional layers
+ *        height (or w). Equals the reciprocal of total stride in
  * \return new symbol
  */
 inline Symbol ROIPooling(Symbol data,
@@ -2118,10 +4556,83 @@ inline Symbol ROIPooling(Symbol data,
 }
 
 /*!
- * \breif Slice input equally along specified axis.
- * \param num_outputs Number of outputs to be sliced. 
- * \param axis Dimension along which to slice. 
- * \param squeeze_axis If true AND the sliced dimension becomes 1, squeeze that dimension. 
+ * \breif Takes the last element of a sequence. Takes an n-dimensional tensor
+ *        of the form [max sequence length, batchsize, other dims] and returns
+ *        a (n-1)-dimensional tensor of the form [batchsize, other dims]. This
+ *        operator takes an optional input tensor sequence_length of positive
+ *        ints of dimension [batchsize] when the sequence_length option is set
+ *        to true. This allows the operator to handle variable-length
+ *        sequences. If sequence_length is false, then each example in the
+ * \param data n-dimensional input tensor of the form [max sequence length,
+ * \param sequence_length vector of sequence lengths of size batchsize
+ * \param use_sequence_length If set to true, this layer takes in extra input
+ * \return new symbol
+ */
+inline Symbol SequenceLast(Symbol data,
+                           Symbol sequence_length,
+                           bool use_sequence_length = false) {
+  return Operator("SequenceLast")
+           .SetParam("use_sequence_length", use_sequence_length)
+           .SetInput("data", data)
+           .SetInput("sequence_length", sequence_length)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Sets all elements outside the sequence to a constant value. Takes an
+ *        n-dimensional tensor of the form [max sequence length, batchsize,
+ *        other dims] and returns a tensor of the same shape. This operator
+ *        takes an optional input tensor sequence_length of positive ints of
+ *        dimension [batchsize] when the sequence_length option is set to
+ *        true. This allows the operator to handle variable-length sequences.
+ *        If sequence_length is false, then each example in the batch is
+ *        assumed to have the max sequence length, and this operator becomes
+ * \param data n-dimensional input tensor of the form [max sequence length,
+ * \param sequence_length vector of sequence lengths of size batchsize
+ * \param use_sequence_length If set to true, this layer takes in extra input
+ * \param value The value to be used as a mask.
+ * \return new symbol
+ */
+inline Symbol SequenceMask(Symbol data,
+                           Symbol sequence_length,
+                           bool use_sequence_length = false,
+                           mx_float value = 0) {
+  return Operator("SequenceMask")
+           .SetParam("use_sequence_length", use_sequence_length)
+           .SetParam("value", value)
+           .SetInput("data", data)
+           .SetInput("sequence_length", sequence_length)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Reverses the elements of each sequence. Takes an n-dimensional tensor
+ *        of the form [max sequence length, batchsize, other dims] and returns
+ *        a tensor of the same shape. This operator takes an optional input
+ *        tensor sequence_length of positive ints of dimension [batchsize]
+ *        when the sequence_length option is set to true. This allows the
+ *        operator to handle variable-length sequences. If sequence_length is
+ *        false, then each example in the batch is assumed to have the max
+ * \param data n-dimensional input tensor of the form [max sequence length,
+ * \param sequence_length vector of sequence lengths of size batchsize
+ * \param use_sequence_length If set to true, this layer takes in extra input
+ * \return new symbol
+ */
+inline Symbol SequenceReverse(Symbol data,
+                              Symbol sequence_length,
+                              bool use_sequence_length = false) {
+  return Operator("SequenceReverse")
+           .SetParam("use_sequence_length", use_sequence_length)
+           .SetInput("data", data)
+           .SetInput("sequence_length", sequence_length)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Slice input equally along specified axis
+ * \param num_outputs Number of outputs to be sliced.
+ * \param axis Dimension along which to slice.
+ * \param squeeze_axis If true AND the sliced dimension becomes 1, squeeze that
  * \return new symbol
  */
 inline Symbol SliceChannel(int num_outputs,
@@ -2135,34 +4646,17 @@ inline Symbol SliceChannel(int num_outputs,
 }
 
 /*!
- * \breif Calculate Smooth L1 Loss(lhs, scalar).
- * \param lhs Left symbolic input to the function.
- * \param rhs Left symbolic input to the function.
- * \return new symbol
- */
-inline Symbol smooth_l1(Symbol lhs,
-                        Symbol rhs) {
-  return Operator("smooth_l1")
-           .SetInput("lhs", lhs)
-           .SetInput("rhs", rhs)
-           .CreateSymbol();
-}
-
-/*!
- * \breif Apply softmax activation to input.
- *        This is intended for internal layers. For output (loss layer) please
- *        use SoftmaxOutput. If type=instance, this operator will compute a
- *        softmax for each instance in the batch; this is the default mode. If
- *        type=channel, this operator will compute a num_channel-class softmax
- *        at each position of each instance; this can be used for fully
- *        convolutional network, image segmentation, etc.
- * \param data Input data to activation function. 
- * \param mode Softmax Mode.
- *        If set to instance, this operator will compute a softmax for each
- *        instance in the batch; this is the default mode. If set to channel,
+ * \breif Apply softmax activation to input. This is intended for internal
+ *        layers. For output (loss layer) please use SoftmaxOutput. If
+ *        mode=instance, this operator will compute a softmax for each
+ *        instance in the batch; this is the default mode. If mode=channel,
  *        this operator will compute a num_channel-class softmax at each
  *        position of each instance; this can be used for fully convolutional
- *        network, image segmentation, etc.
+ * \param data Input data to activation function.
+ * \param mode Softmax Mode. If set to instance, this operator will compute a
+ *        softmax for each instance in the batch; this is the default mode. If
+ *        set to channel, this operator will compute a num_channel-class
+ *        softmax at each position of each instance; this can be used for
  * \return new symbol
  */
 inline Symbol SoftmaxActivation(Symbol data,
@@ -2178,19 +4672,20 @@ inline Symbol SoftmaxActivation(Symbol data,
 }
 
 /*!
- * \breif Perform a softmax transformation on input, backprop with logloss. 
- * \param data Input data to softmax. 
- * \param label Label data. 
- * \param grad_scale Scale the gradient by a float factor.
+ * \breif Perform a softmax transformation on input, backprop with logloss.
+ * \param data Input data to softmax.
+ * \param label Label data, can also be probability value with same shape as
+ * \param grad_scale Scale the gradient by a float factor
  * \param ignore_label the label value will be ignored during backward (only
- *        works if use_ignore is set to be true).
  * \param multi_output If set to true, for a (n,k,x_1,..,x_n) dimensional input
- *        tensor, softmax will generate n*x_1*...*x_n output, each has k classes
+ *        tensor, softmax will generate n*x_1*...*x_n output, each has k
  * \param use_ignore If set to true, the ignore_label value will not contribute
- *        to the backward gradient
- * \param normalization If set to null, op will do nothing on output gradient.
- *        If set to batch, op will normalize gradient by divide batch sizeIf
- *        set to valid, op will normalize gradient by divide sample not ignored
+ * \param preserve_shape If true, for a (n_1, n_2, ..., n_d, k) dimensional
+ *        input tensor, softmax will generate (n1, n2, ..., n_d, k) output,
+ * \param normalization If set to null, op will do nothing on output
+ *        gradient.If set to batch, op will normalize gradient by divide batch
+ *        sizeIf set to valid, op will normalize gradient by divide sample not
+ * \param out_grad Apply weighting from output gradient
  * \return new symbol
  */
 inline Symbol SoftmaxOutput(Symbol data,
@@ -2199,7 +4694,9 @@ inline Symbol SoftmaxOutput(Symbol data,
                             mx_float ignore_label = -1,
                             bool multi_output = false,
                             bool use_ignore = false,
-                            SoftmaxOutputNormalization normalization = SoftmaxOutputNormalization::null) {
+                            bool preserve_shape = false,
+                            SoftmaxOutputNormalization normalization = SoftmaxOutputNormalization::null,
+                            bool out_grad = false) {
   static const char *SoftmaxOutputNormalizationValues[] = {
     "batch",
     "null",
@@ -2210,26 +4707,28 @@ inline Symbol SoftmaxOutput(Symbol data,
            .SetParam("ignore_label", ignore_label)
            .SetParam("multi_output", multi_output)
            .SetParam("use_ignore", use_ignore)
+           .SetParam("preserve_shape", preserve_shape)
            .SetParam("normalization", SoftmaxOutputNormalizationValues[int(normalization)])
+           .SetParam("out_grad", out_grad)
            .SetInput("data", data)
            .SetInput("label", label)
            .CreateSymbol();
 }
 
 /*!
- * \breif DEPRECATED: Perform a softmax transformation on input.
- *        Please use SoftmaxOutput
- * \param data Input data to softmax. 
- * \param grad_scale Scale the gradient by a float factor.
+ * \breif DEPRECATED: Perform a softmax transformation on input. Please use
+ * \param data Input data to softmax.
+ * \param grad_scale Scale the gradient by a float factor
  * \param ignore_label the label value will be ignored during backward (only
- *        works if use_ignore is set to be true).
  * \param multi_output If set to true, for a (n,k,x_1,..,x_n) dimensional input
- *        tensor, softmax will generate n*x_1*...*x_n output, each has k classes
+ *        tensor, softmax will generate n*x_1*...*x_n output, each has k
  * \param use_ignore If set to true, the ignore_label value will not contribute
- *        to the backward gradient
- * \param normalization If set to null, op will do nothing on output gradient.
- *        If set to batch, op will normalize gradient by divide batch sizeIf
- *        set to valid, op will normalize gradient by divide sample not ignored
+ * \param preserve_shape If true, for a (n_1, n_2, ..., n_d, k) dimensional
+ *        input tensor, softmax will generate (n1, n2, ..., n_d, k) output,
+ * \param normalization If set to null, op will do nothing on output
+ *        gradient.If set to batch, op will normalize gradient by divide batch
+ *        sizeIf set to valid, op will normalize gradient by divide sample not
+ * \param out_grad Apply weighting from output gradient
  * \return new symbol
  */
 inline Symbol Softmax(Symbol data,
@@ -2237,7 +4736,9 @@ inline Symbol Softmax(Symbol data,
                       mx_float ignore_label = -1,
                       bool multi_output = false,
                       bool use_ignore = false,
-                      SoftmaxNormalization normalization = SoftmaxNormalization::null) {
+                      bool preserve_shape = false,
+                      SoftmaxNormalization normalization = SoftmaxNormalization::null,
+                      bool out_grad = false) {
   static const char *SoftmaxNormalizationValues[] = {
     "batch",
     "null",
@@ -2248,16 +4749,72 @@ inline Symbol Softmax(Symbol data,
            .SetParam("ignore_label", ignore_label)
            .SetParam("multi_output", multi_output)
            .SetParam("use_ignore", use_ignore)
+           .SetParam("preserve_shape", preserve_shape)
            .SetParam("normalization", SoftmaxNormalizationValues[int(normalization)])
+           .SetParam("out_grad", out_grad)
            .SetInput("data", data)
            .CreateSymbol();
 }
 
 /*!
- * \breif Apply swapaxis to input. 
- * \param data Input data to the SwapAxisOp. 
- * \param dim1 the first axis to be swapped. 
- * \param dim2 the second axis to be swapped. 
+ * \breif Apply spatial transformer to input feature map.
+ * \param data Input data to the SpatialTransformerOp.
+ * \param loc localisation net, the output dim should be 6 when transform_type
+ *        is affine, and the name of loc symbol should better starts with
+ *        'stn_loc', so that initialization it with iddentify tranform, or you
+ * \param transform_type transformation type
+ * \param sampler_type sampling type
+ * \param target_shape output shape(h, w) of spatial transformer: (y, x)
+ * \return new symbol
+ */
+inline Symbol SpatialTransformer(Symbol data,
+                                 Symbol loc,
+                                 SpatialTransformerTransformType transform_type,
+                                 SpatialTransformerSamplerType sampler_type,
+                                 Shape target_shape = Shape(0,0)) {
+  static const char *SpatialTransformerTransformTypeValues[] = {
+    "affine"
+  };
+  static const char *SpatialTransformerSamplerTypeValues[] = {
+    "bilinear"
+  };
+  return Operator("SpatialTransformer")
+           .SetParam("transform_type", SpatialTransformerTransformTypeValues[int(transform_type)])
+           .SetParam("sampler_type", SpatialTransformerSamplerTypeValues[int(sampler_type)])
+           .SetParam("target_shape", target_shape)
+           .SetInput("data", data)
+           .SetInput("loc", loc)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Support Vector Machine based transformation on input, backprop L2-SVM
+ * \param data Input data to svm.
+ * \param label Label data.
+ * \param margin Scale the DType(param_.margin) for activation size
+ * \param regularization_coefficient Scale the coefficient responsible for
+ * \param use_linear If set true, uses L1-SVM objective function. Default uses
+ * \return new symbol
+ */
+inline Symbol SVMOutput(Symbol data,
+                        Symbol label,
+                        mx_float margin = 1,
+                        mx_float regularization_coefficient = 1,
+                        bool use_linear = false) {
+  return Operator("SVMOutput")
+           .SetParam("margin", margin)
+           .SetParam("regularization_coefficient", regularization_coefficient)
+           .SetParam("use_linear", use_linear)
+           .SetInput("data", data)
+           .SetInput("label", label)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Apply swapaxis to input.
+ * \param data Input data to the SwapAxisOp.
+ * \param dim1 the first axis to be swapped.
+ * \param dim2 the second axis to be swapped.
  * \return new symbol
  */
 inline Symbol SwapAxis(Symbol data,
@@ -2271,21 +4828,19 @@ inline Symbol SwapAxis(Symbol data,
 }
 
 /*!
- * \breif Perform nearest neighboor/bilinear up sampling to inputs.
- * \param data Array of tensors to upsample.
- * \param scale Up sampling scale.
- * \param sample_type upsampling method.
- * \param num_args Number of inputs to be upsampled.
- *        For nearest neighbor upsampling, this can be 1-N; the size of output
- *        will be(scale*h_0,scale*w_0) and all other inputs will be upsampled
- *        to thesame size. For bilinear upsampling this must be 2; 1 input and 1 weight.
- * \param num_filter Input filter.
- *        Only used by nearest sample_type.
- * \param multi_input_mode How to handle multiple input.
- *        concat means concatenate upsampled images along the channel
- *        dimension. sum means add all images together, only available for
- *        nearest neighbor upsampling.
- * \param workspace Tmp workspace for deconvolution (MB).
+ * \breif Perform nearest neighboor/bilinear up sampling to inputs
+ * \param data Array of tensors to upsample
+ * \param scale Up sampling scale
+ * \param sample_type upsampling method
+ * \param num_args Number of inputs to be upsampled. For nearest neighbor
+ *        upsampling, this can be 1-N; the size of output will
+ *        be(scale*h_0,scale*w_0) and all other inputs will be upsampled to
+ *        thesame size. For bilinear upsampling this must be 2; 1 input and 1
+ * \param num_filter Input filter. Only used by bilinear sample_type.
+ * \param multi_input_mode How to handle multiple input. concat means
+ *        concatenate upsampled images along the channel dimension. sum means
+ *        add all images together, only available for nearest neighbor
+ * \param workspace Tmp workspace for deconvolution (MB)
  * \return new symbol
  */
 inline Symbol UpSampling(const std::vector<Symbol>& data,
@@ -2311,6 +4866,56 @@ inline Symbol UpSampling(const std::vector<Symbol>& data,
            .SetParam("multi_input_mode", UpSamplingMultiInputModeValues[int(multi_input_mode)])
            .SetParam("workspace", workspace)
 (data)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Choose one element from each line(row for python, column for R/Julia)
+ *        in lhs according to index indicated by rhs. This function assume rhs
+ * \param lhs Left operand to the function.
+ * \param rhs Right operand to the function.
+ * \return new symbol
+ */
+inline Symbol choose_element_0index(Symbol lhs,
+                                    Symbol rhs) {
+  return Operator("choose_element_0index")
+           .SetInput("lhs", lhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Fill one element of each line(row for python, column for R/Julia) in
+ *        lhs according to index indicated by rhs and values indicated by mhs.
+ * \param lhs Left operand to the function.
+ * \param mhs Middle operand to the function.
+ * \param rhs Right operand to the function.
+ * \return new symbol
+ */
+inline Symbol fill_element_0index(Symbol lhs,
+                                  Symbol mhs,
+                                  Symbol rhs) {
+  return Operator("fill_element_0index")
+           .SetInput("lhs", lhs)
+           .SetInput("mhs", mhs)
+           .SetInput("rhs", rhs)
+           .CreateSymbol();
+}
+
+/*!
+ * \breif Clip ndarray elements to range (a_min, a_max)
+ * \param src Source input
+ * \param a_min Minimum value
+ * \param a_max Maximum value
+ * \return new symbol
+ */
+inline Symbol clip(Symbol src,
+                   mx_float a_min,
+                   mx_float a_max) {
+  return Operator("clip")
+           .SetParam("a_min", a_min)
+           .SetParam("a_max", a_max)
+           .SetInput("src", src)
            .CreateSymbol();
 }
 

--- a/include/mxnet-cpp/op_map.h
+++ b/include/mxnet-cpp/op_map.h
@@ -46,6 +46,17 @@ class OpMap {
       CHECK_EQ(r, 0);
       symbol_creators_[name] = symbol_creators[i];
     }
+
+    nn_uint num_ops;
+    const char **op_names;
+    r = NNListAllOpNames(&num_ops, &op_names);
+    CHECK_EQ(r, 0);
+    for (nn_uint i = 0; i < num_ops; i++) {
+      OpHandle handle;
+      r = NNGetOpHandle(op_names[i], &handle);
+      CHECK_EQ(r, 0);
+      op_handles_[op_names[i]] = handle;
+    }
   }
 
   /*!
@@ -55,11 +66,24 @@ class OpMap {
   * \return handle to the symbol creator
   */
   inline AtomicSymbolCreator GetSymbolCreator(const std::string &name) {
+    if (symbol_creators_.count(name) == 0)
+      return GetOpHandle(name);
     return symbol_creators_[name];
+  }
+
+  /*!
+  * \brief Get an op handle with its name.
+  *
+  * \param name name of the op
+  * \return handle to the op
+  */
+  inline OpHandle GetOpHandle(const std::string &name) {
+    return op_handles_[name];
   }
 
  private:
   std::map<std::string, AtomicSymbolCreator> symbol_creators_;
+  std::map<std::string, OpHandle> op_handles_;
 };
 
 }  // namespace cpp

--- a/include/mxnet-cpp/operator.h
+++ b/include/mxnet-cpp/operator.h
@@ -46,6 +46,22 @@ class Operator {
     return *this;
   }
   /*!
+  * \brief set config parameters from positional inputs
+  * \param pos the position of parameter
+  * \param value value of the config parameter
+  * \return reference of self
+  */
+  template <typename T>
+  Operator &SetParam(int pos, const T &value) {
+    std::string value_str;
+    std::stringstream ss;
+    ss << value;
+    ss >> value_str;
+
+    params_[arg_names_[pos]] = value_str;
+    return *this;
+  }
+  /*!
   * \brief add an input symbol
   * \param name name of the input symbol
   * \param symbol the input symbol
@@ -56,16 +72,9 @@ class Operator {
   * \brief add an input symbol
   * \param symbol the input symbol
   */
+  template<int N=0>
   void PushInput(const Symbol &symbol) {
-    input_values.push_back(symbol.GetHandle());
-  }
-  /*!
-  * \brief add input symbols
-  */
-  template <class T, class... Args>
-  void PushInput(const Symbol &symbol, const T &t, Args... args) {
-    PushInput(symbol);
-    PushInput(t, args...);
+    input_symbols.push_back(symbol.GetHandle());
   }
   /*!
   * \brief add input symbols
@@ -78,7 +87,7 @@ class Operator {
   * \return reference of self
   */
   Operator &operator()(const Symbol &symbol) {
-    input_values.push_back(symbol.GetHandle());
+    input_symbols.push_back(symbol.GetHandle());
     return *this;
   }
   /*!
@@ -88,17 +97,8 @@ class Operator {
   */
   Operator &operator()(const std::vector<Symbol> &symbols) {
     for (auto &s : symbols) {
-      input_values.push_back(s.GetHandle());
+      input_symbols.push_back(s.GetHandle());
     }
-    return *this;
-  }
-  /*!
-  * \brief add input symbols
-  * \return reference of self
-  */
-  template <typename T, typename... Args>
-  Operator &operator()(const Symbol &symbol, const T &t, Args... args) {
-    PushInput(symbol, t, args...);
     return *this;
   }
   /*!
@@ -108,12 +108,77 @@ class Operator {
   */
   Symbol CreateSymbol(const std::string &name = "");
 
+  /*!
+  * \brief add an input ndarray
+  * \param name name of the input ndarray
+  * \param ndarray the input ndarray
+  * \return reference of self
+  */
+  Operator &SetInput(const std::string &name, NDArray ndarray);
+  /*!
+  * \brief add an input ndarray
+  * \param ndarray the input ndarray
+  */
+  template<int N=0>
+  void PushInput(const NDArray &ndarray) {
+    input_ndarrays.push_back(ndarray.GetHandle());
+  }
+  /*!
+  * \brief add positional inputs
+  */
+  template <class T, class... Args, int N=0>
+  void PushInput(const T &t, Args... args) {
+    SetParam(N, t);
+    PushInput<Args..., N+1>(args...);
+  }
+  /*!
+  * \brief add the last positional input
+  */
+  template <class T, int N=0>
+  void PushInput(const T &t) {
+    SetParam(N, t);
+  }
+  /*!
+  * \brief add input ndarrays
+  * \param ndarray the input ndarray
+  * \return reference of self
+  */
+  Operator &operator()(const NDArray &ndarray) {
+    input_ndarrays.push_back(ndarray.GetHandle());
+    return *this;
+  }
+  /*!
+  * \brief add a list of input ndarrays
+  * \param ndarrays the vector of the input ndarrays
+  * \return reference of self
+  */
+  Operator &operator()(const std::vector<NDArray> &ndarrays) {
+    for (auto &s : ndarrays) {
+      input_ndarrays.push_back(s.GetHandle());
+    }
+    return *this;
+  }
+  /*!
+  * \brief add input ndarrays
+  * \return reference of self
+  */
+  template <typename... Args>
+  Operator &operator()(Args... args) {
+    PushInput(args...);
+    return *this;
+  }
+  std::vector<NDArray> Invoke();
+  void Invoke(NDArray &output);
+  void Invoke(std::vector<NDArray> &outputs);
+
  private:
   std::map<std::string, std::string> params_desc_;
   bool variable_params_ = false;
   std::map<std::string, std::string> params_;
-  std::vector<SymbolHandle> input_values;
+  std::vector<SymbolHandle> input_symbols;
+  std::vector<NDArrayHandle> input_ndarrays;
   std::vector<std::string> input_keys;
+  std::vector<std::string> arg_names_;
   AtomicSymbolCreator handle_;
   static OpMap *op_map_;
 };

--- a/include/mxnet-cpp/operator.h
+++ b/include/mxnet-cpp/operator.h
@@ -72,7 +72,7 @@ class Operator {
   * \brief add an input symbol
   * \param symbol the input symbol
   */
-  template<int N=0>
+  template<int N = 0>
   void PushInput(const Symbol &symbol) {
     input_symbols.push_back(symbol.GetHandle());
   }
@@ -119,14 +119,14 @@ class Operator {
   * \brief add an input ndarray
   * \param ndarray the input ndarray
   */
-  template<int N=0>
+  template<int N = 0>
   void PushInput(const NDArray &ndarray) {
     input_ndarrays.push_back(ndarray.GetHandle());
   }
   /*!
   * \brief add positional inputs
   */
-  template <class T, class... Args, int N=0>
+  template <class T, class... Args, int N = 0>
   void PushInput(const T &t, Args... args) {
     SetParam(N, t);
     PushInput<Args..., N+1>(args...);
@@ -134,7 +134,7 @@ class Operator {
   /*!
   * \brief add the last positional input
   */
-  template <class T, int N=0>
+  template <class T, int N = 0>
   void PushInput(const T &t) {
     SetParam(N, t);
   }

--- a/include/mxnet-cpp/operator.hpp
+++ b/include/mxnet-cpp/operator.hpp
@@ -16,13 +16,50 @@
 
 namespace mxnet {
 namespace cpp {
+
+/*
+ * Pushing NDArray or Symbol as inputs here to avoid partial specialization
+ * like PushInput<NDArray, Args..., N>, which is not allowed in C++
+ */
+template <>
+Operator& Operator::SetParam<NDArray>(int pos, const NDArray &value) {
+  input_ndarrays.push_back(value.GetHandle());
+  return *this;
+}
+template <>
+Operator& Operator::SetParam<Symbol>(int pos, const Symbol &value) {
+  input_symbols.push_back(value.GetHandle());
+  return *this;
+}
+
 OpMap *Operator::op_map_ = new OpMap();
 
 Operator::Operator(const std::string &operator_name) {
   handle_ = op_map_->GetSymbolCreator(operator_name);
+  const char *name;
+  const char *description;
+  mx_uint num_args;
+  const char **arg_names;
+  const char **arg_type_infos;
+  const char **arg_descriptions;
+  const char *key_var_num_args;
+  MXSymbolGetAtomicSymbolInfo(handle_,
+      &name,
+      &description,
+      &num_args,
+      &arg_names,
+      &arg_type_infos,
+      &arg_descriptions,
+      &key_var_num_args);
+  for (mx_uint i=0; i<num_args; ++i) {
+    arg_names_.push_back(arg_names[i]);
+  }
 }
 
 Symbol Operator::CreateSymbol(const std::string &name) {
+  if (input_keys.size() > 0) {
+    CHECK_EQ(input_keys.size(), input_symbols.size());
+  }
   const char *pname = name == "" ? nullptr : name.c_str();
 
   SymbolHandle symbol_handle;
@@ -42,15 +79,74 @@ Symbol Operator::CreateSymbol(const std::string &name) {
 
   MXSymbolCreateAtomicSymbol(handle_, param_keys.size(), param_keys.data(),
                              param_values.data(), &symbol_handle);
-  MXSymbolCompose(symbol_handle, pname, input_values.size(), input_keys_p,
-                  input_values.data());
+  MXSymbolCompose(symbol_handle, pname, input_symbols.size(), input_keys_p,
+                  input_symbols.data());
   return Symbol(symbol_handle);
 }
+
+void Operator::Invoke(std::vector<NDArray> &outputs) {
+  if (input_keys.size() > 0) {
+    CHECK_EQ(input_keys.size(), input_ndarrays.size());
+  }
+
+  std::vector<const char *> input_keys;
+  std::vector<const char *> param_keys;
+  std::vector<const char *> param_values;
+
+  for (auto &data : params_) {
+    param_keys.push_back(data.first.c_str());
+    param_values.push_back(data.second.c_str());
+  }
+
+  int num_inputs = input_ndarrays.size();
+  int num_outputs = outputs.size();
+  std::vector<NDArrayHandle> output_handles;
+  std::transform(outputs.begin(), outputs.end(),
+      std::back_inserter(output_handles), [](NDArray& a) {
+        return a.GetHandle();
+      });
+
+  NDArrayHandle *outputs_receiver = nullptr;
+  if (num_outputs > 0) {
+    outputs_receiver = output_handles.data();
+  }
+
+  MXImperativeInvoke(handle_, num_inputs, input_ndarrays.data(),
+      &num_outputs, &outputs_receiver,
+      param_keys.size(), param_keys.data(), param_values.data());
+
+  if (outputs.size() > 0)
+    return;
+
+  std::transform(outputs_receiver, outputs_receiver+num_outputs,
+      std::back_inserter(outputs), [](const NDArrayHandle& handle) {
+        return NDArray(handle);
+      });
+}
+
+std::vector<NDArray> Operator::Invoke() {
+  std::vector<NDArray> outputs;
+  Invoke(outputs);
+  return outputs;
+}
+
+void Operator::Invoke(NDArray &output) {
+  std::vector<NDArray> outputs{output};
+  Invoke(outputs);
+}
+
 Operator &Operator::SetInput(const std::string &name, Symbol symbol) {
   input_keys.push_back(name.c_str());
-  input_values.push_back(symbol.GetHandle());
+  input_symbols.push_back(symbol.GetHandle());
   return *this;
 }
+
+Operator &Operator::SetInput(const std::string &name, NDArray ndarray) {
+  input_keys.push_back(name.c_str());
+  input_ndarrays.push_back(ndarray.GetHandle());
+  return *this;
+}
+
 }  // namespace cpp
 }  // namespace mxnet
 

--- a/include/mxnet-cpp/operator.hpp
+++ b/include/mxnet-cpp/operator.hpp
@@ -8,6 +8,7 @@
 #ifndef MXNETCPP_OPERATOR_HPP
 #define MXNETCPP_OPERATOR_HPP
 
+#include <algorithm>
 #include <string>
 #include <vector>
 #include "mxnet-cpp/base.h"
@@ -51,7 +52,7 @@ Operator::Operator(const std::string &operator_name) {
       &arg_type_infos,
       &arg_descriptions,
       &key_var_num_args);
-  for (mx_uint i=0; i<num_args; ++i) {
+  for (mx_uint i = 0; i < num_args; ++i) {
     arg_names_.push_back(arg_names[i]);
   }
 }

--- a/include/mxnet-cpp/optimizer.h
+++ b/include/mxnet-cpp/optimizer.h
@@ -9,10 +9,14 @@
 #define MXNETCPP_OPTIMIZER_H
 
 #include <map>
+#include <vector>
 #include <string>
+#include <memory>
+#include <functional>
 #include "mxnet-cpp/base.h"
 #include "mxnet-cpp/logging.h"
 #include "mxnet-cpp/ndarray.h"
+#include "mxnet-cpp/op_map.h"
 
 namespace mxnet {
 namespace cpp {
@@ -23,19 +27,14 @@ namespace cpp {
 class Optimizer {
  public:
   /*!
-  * \brief Operator constructor, the optimizer is not initialized until the
-  * first Update
-  * \param opt_type type of the optimizer
-  * \param learning_rate
-  * \param weight_decay
+  * \brief get optimizer type
+  * \return string of optimizer type
   */
-  Optimizer(const std::string &opt_type, mx_float learning_rate, mx_float weight_decay);
+  virtual std::string GetType() const = 0;
   /*!
-  * \brief destructor, free the handle
+  * \brief destructor
   */
-  ~Optimizer() {
-    if (init_) MXOptimizerFree(handle_);
-  }
+  virtual ~Optimizer();
   /*!
   * \brief set config parameters
   * \param name name of the config parameter
@@ -43,32 +42,32 @@ class Optimizer {
   * \return reference of self
   */
   template <typename T>
-  Optimizer &SetParam(const std::string &name, const T &value) {
+  Optimizer *SetParam(const std::string &name, const T &value) {
     std::string value_str;
     std::stringstream ss;
     ss << value;
     ss >> value_str;
 
     params_[name] = value_str;
-    return *this;
+    return this;
   }
   /*!
   *  \brief Update a weight with gradient.
   *  \param index the unique index for the weight.
   *  \param weight the weight to update.
   *  \param grad gradient for the weight.
-  *  \param learning_rate learning rate.
-  *  \param weight_decay weight decay.
+  *  \param lr learning rate.
+  *  \param wd weight decay.
   */
-  void Update(int index, NDArray weight, NDArray grad, mx_float learning_rate,
-              mx_float weight_decay);
+  void Update(int index, NDArray weight, NDArray grad, mx_float lr,
+              mx_float wd);
   /*!
   *  \brief Update a weight with gradient.
   *  \param index the unique index for the weight.
   *  \param weight the weight to update.
   *  \param grad gradient for the weight.
   */
-  void Update(int index, NDArray weight, NDArray grad);
+  virtual void Update(int index, NDArray weight, NDArray grad) = 0;
   // TODO(zhangcheng-qinyinghua)
   // implement Update a list of arrays, maybe in the form of map
   // void Update(int index, std::vector<NDArray> weights, std::vector<NDArray>
@@ -80,16 +79,45 @@ class Optimizer {
   */
   std::string Serialize() const;
 
- private:
-  bool init_;
-  mx_float learning_rate_, weight_decay_;
-  std::string opt_type_;
-  Optimizer(const Optimizer &);
-  Optimizer &operator=(const Optimizer &);
-  OptimizerHandle handle_;
-  OptimizerCreator creator_;
+ protected:
   std::map<std::string, std::string> params_;
+  static OpMap *op_map_;
+  const std::vector<const char*> GetParamKeys_() const;
+  const std::vector<const char*> GetParamValues_() const;
 };
+
+typedef std::function<Optimizer*()> OptimizerCreator;
+
+class OptimizerRegistry {
+ public:
+  static Optimizer* Find(const std::string& name);
+  static int __REGISTER__(const std::string& name, OptimizerCreator creator);
+ private:
+  static std::map<std::string, OptimizerCreator> cmap_;
+  OptimizerRegistry() = delete;
+  ~OptimizerRegistry() = delete;
+};
+
+#define MXNETCPP_REGISTER_OPTIMIZER(Name, OptimizerType)          \
+  static int __make_ ## OptimizerType ## _ ## Name ## __ = \
+       OptimizerRegistry::__REGISTER__(#Name, [](){return new OptimizerType();})
+
+class SGDOptimizer : public Optimizer {
+ public:
+  SGDOptimizer();
+  virtual std::string GetType() const;
+  virtual void Update(int index, NDArray weight, NDArray grad);
+ private:
+  virtual ~SGDOptimizer();
+  virtual void CreateState_(int index, NDArray weight);
+  std::map<int, NDArray*> states_;
+  AtomicSymbolCreator update_handle_;
+  AtomicSymbolCreator mom_update_handle_;
+};
+MXNETCPP_REGISTER_OPTIMIZER(sgd, SGDOptimizer);
+MXNETCPP_REGISTER_OPTIMIZER(ccsgd, SGDOptimizer);  // For backward compatibility
+
+
 }  // namespace cpp
 }  // namespace mxnet
 

--- a/include/mxnet-cpp/optimizer.h
+++ b/include/mxnet-cpp/optimizer.h
@@ -97,6 +97,7 @@ class OptimizerRegistry {
   OptimizerRegistry() = delete;
   ~OptimizerRegistry() = delete;
 };
+std::map<std::string, OptimizerCreator> OptimizerRegistry::cmap_;
 
 #define MXNETCPP_REGISTER_OPTIMIZER(Name, OptimizerType)          \
   static int __make_ ## OptimizerType ## _ ## Name ## __ = \

--- a/include/mxnet-cpp/optimizer.hpp
+++ b/include/mxnet-cpp/optimizer.hpp
@@ -8,54 +8,125 @@
 #ifndef MXNETCPP_OPTIMIZER_HPP
 #define MXNETCPP_OPTIMIZER_HPP
 
+#include <algorithm>
+#include <utility>
 #include <numeric>
 #include <map>
 #include <string>
 #include <vector>
 #include "mxnet-cpp/optimizer.h"
+#include "mxnet-cpp/op.h"
+#include "mxnet-cpp/op_map.h"
 
 namespace mxnet {
 namespace cpp {
 
-Optimizer::Optimizer(const std::string &opt_type, mx_float learning_rate, mx_float weight_decay)
-  :init_(false), learning_rate_(learning_rate), weight_decay_(weight_decay), opt_type_(opt_type) {
-  MXOptimizerFindCreator(opt_type.c_str(), &creator_);
-}
+OpMap* Optimizer::op_map_ = new OpMap();
 
-void Optimizer::Update(int index, NDArray weight, NDArray grad, mx_float learning_rate,
-                       mx_float weight_decay) {
-  if (!init_) {
-    std::vector<const char *> param_keys;
-    std::vector<const char *> param_values;
-    for (const auto &k_v : params_) {
-      param_keys.push_back(k_v.first.c_str());
-      param_values.push_back(k_v.second.c_str());
-    }
-    MXOptimizerCreateOptimizer(creator_, params_.size(), param_keys.data(),
-                               param_values.data(), &handle_);
-    init_ = true;
-  }
-  learning_rate_ = learning_rate;
-  weight_decay_ = weight_decay;
-  MXOptimizerUpdate(handle_, index, weight.GetHandle(), grad.GetHandle(),
-      learning_rate_, weight_decay_);
-}
+Optimizer::~Optimizer() {}
 
-void Optimizer::Update(int index, NDArray weight, NDArray grad) {
-  Update(index, weight, grad, learning_rate_, weight_decay_);
+void Optimizer::Update(int index, NDArray weight, NDArray grad, mx_float lr,
+                       mx_float wd) {
+  params_["lr"] = std::to_string(lr);
+  params_["wd"] = std::to_string(wd);
+  Update(index, weight, grad);
 }
 
 std::string Optimizer::Serialize() const {
   using ValueType = std::map<std::string, std::string>::value_type;
   auto params = params_;
-  params.emplace("opt_type", opt_type_);
-  params.emplace("learning_rate", std::to_string(learning_rate_));
-  params.emplace("weight_decay", std::to_string(weight_decay_));
+  params.emplace("opt_type", GetType());
   return std::accumulate(params.cbegin(), params.cend(), std::string(""),
     [](const std::string& sum, const ValueType& i) {
       return sum + '\n' + i.first + '=' + i.second;
     }).substr(1);
 }
+
+const std::vector<const char*> Optimizer::GetParamKeys_() const {
+  std::vector<const char*> keys;
+  std::transform(params_.begin(), params_.end(), std::back_inserter(keys),
+      [](const std::pair<std::string, std::string>& pair){
+        return pair.first.c_str();
+      });
+  return keys;
+}
+
+const std::vector<const char*> Optimizer::GetParamValues_() const {
+  std::vector<const char*> values;
+  std::transform(params_.begin(), params_.end(), std::back_inserter(values),
+      [](const std::pair<std::string, std::string>& pair){
+        return pair.second.c_str();
+      });
+  return values;
+}
+
+Optimizer* OptimizerRegistry::Find(const std::string& name) {
+  auto it = cmap_.find(name);
+  if (it == cmap_.end())
+    return nullptr;
+  return it->second();
+}
+
+int OptimizerRegistry::__REGISTER__(const std::string& name, OptimizerCreator creator) {
+  CHECK_EQ(cmap_.count(name), 0) << name << " already registered";
+  cmap_.emplace(name, std::move(creator));
+  return 0;
+}
+
+std::string SGDOptimizer::GetType() const {
+  return "sgd";
+}
+
+SGDOptimizer::SGDOptimizer() {
+  update_handle_ = op_map_->GetSymbolCreator("sgd_update");
+  mom_update_handle_ = op_map_->GetSymbolCreator("sgd_mom_update");
+}
+
+SGDOptimizer::~SGDOptimizer() {
+  for (auto &it : states_) {
+    delete it.second;
+  }
+}
+
+void SGDOptimizer::Update(int index, NDArray weight, NDArray grad) {
+  if (states_.count(index) == 0) {
+    CreateState_(index, weight);
+  }
+
+  auto keys = GetParamKeys_();
+  auto values = GetParamValues_();
+  CHECK_EQ(keys.size(), values.size());
+
+  NDArrayHandle inputs[3];
+  inputs[0] = weight.GetHandle();
+  inputs[1] = grad.GetHandle();
+
+  int num_outputs = 1;
+  NDArrayHandle output = weight.GetHandle();
+  NDArrayHandle *outputs = &output;
+
+  if (states_[index] == nullptr) {
+    MXImperativeInvoke(update_handle_, 2, inputs,
+        &num_outputs, &outputs,
+        keys.size(), keys.data(), values.data());
+  } else {
+    inputs[2] = states_[index]->GetHandle();
+    MXImperativeInvoke(mom_update_handle_, 3, inputs,
+        &num_outputs, &outputs,
+        keys.size(), keys.data(), values.data());
+  }
+}
+
+void SGDOptimizer::CreateState_(int index, NDArray weight) {
+  if (params_.count("momentum") == 0) {
+    states_[index] = nullptr;
+  } else {
+    states_[index] = new NDArray(weight.GetShape(), weight.GetContext());
+    *states_[index] = 0;
+  }
+}
+
+
 }  // namespace cpp
 }  // namespace mxnet
 

--- a/include/mxnet-cpp/shape.h
+++ b/include/mxnet-cpp/shape.h
@@ -293,7 +293,7 @@ struct Shape {
   // when dimension is smaller than kStackCache
   // when it is bigger, it will be stored in data_heap_;
   /*! \brief size of in stack space */
-  static const index_t kStackCache = 4;
+  static const index_t kStackCache = 5;
   /*! \brief number of dimnsion of the shape */
   index_t ndim_;
   /*! \brief number of cells allocated in data_heap_ */

--- a/src/OpWrapperGenerator/OpWrapperGenerator.py
+++ b/src/OpWrapperGenerator/OpWrapperGenerator.py
@@ -1,4 +1,5 @@
 ﻿from ctypes import *
+from ctypes.util import find_library
 import logging
 import platform
 import re
@@ -46,10 +47,14 @@ class Arg:
     typeDict = {'boolean':'bool',\
         'Shape(tuple)':'Shape',\
         'Symbol':'Symbol',\
+        'NDArray':'Symbol',\
         'Symbol[]':'const std::vector<Symbol>&',\
+        'NDArray[]':'const std::vector<Symbol>&',\
         'float':'mx_float',\
+        'real_t':'mx_float',\
         'int':'int',\
         'long':'int64_t',\
+        'double':'double',\
         'string':'const std::string&'}
     name = ''
     type = ''
@@ -245,6 +250,8 @@ def ParseAllOps():
     """
     if platform.system() == "Linux":
       cdll.libmxnet = cdll.LoadLibrary('../../lib/linux/libmxnet.so')
+    else:
+      cdll.libmxnet = cdll.LoadLibrary(find_library('mxnet'))
     ListOP = cdll.libmxnet.MXSymbolListAtomicSymbolCreators
     GetOpInfo = cdll.libmxnet.MXSymbolGetAtomicSymbolInfo
     ListOP.argtypes=[POINTER(c_int), POINTER(POINTER(c_void_p))]
@@ -285,6 +292,8 @@ def ParseAllOps():
         args = []
 
         for i in range(0, nArgs.value):
+            if name.value.decode() == 'ElementWiseSum':
+                print argNames[i].decode() + argTypes[i].decode()
             arg = Arg(name.value.decode(),
                       argNames[i].decode(),
                       argTypes[i].decode(),


### PR DESCRIPTION
1. Port optimizer to mxnet.cpp
2. Add imperative operator support
3. Fix op generator

Tested using lenet_with_mxdataiter

Bugs from upstream:
1. ~nnvm doesn't parse empty tuple correctly (affets op initialization when the default values of shape parameters are empty)~ (FIXED)
2. missing argument information for `Activation` (affects op generator only)
3. missing type name for `nnvm::Tuple<int>`, which is used in operator `Reshape` as type of `target_shape` (ditto)