### PR TITLE
Fix declarations that prevented use of MXNet.cpp in multi-file C++ projects. 

### DIFF
--- a/include/mxnet-cpp/op.h
+++ b/include/mxnet-cpp/op.h
@@ -12,7 +12,7 @@
 #include <vector>
 #include "mxnet-cpp/base.h"
 #include "mxnet-cpp/shape.h"
-#include "mxnet-cpp/MxNetCpp.h"
+#include "mxnet-cpp/operator.h"
 
 namespace mxnet {
 namespace cpp {

--- a/include/mxnet-cpp/optimizer.h
+++ b/include/mxnet-cpp/optimizer.h
@@ -97,7 +97,6 @@ class OptimizerRegistry {
   OptimizerRegistry() = delete;
   ~OptimizerRegistry() = delete;
 };
-std::map<std::string, OptimizerCreator> OptimizerRegistry::cmap_;
 
 #define MXNETCPP_REGISTER_OPTIMIZER(Name, OptimizerType)          \
   static int __make_ ## OptimizerType ## _ ## Name ## __ = \
@@ -115,8 +114,6 @@ class SGDOptimizer : public Optimizer {
   AtomicSymbolCreator update_handle_;
   AtomicSymbolCreator mom_update_handle_;
 };
-MXNETCPP_REGISTER_OPTIMIZER(sgd, SGDOptimizer);
-MXNETCPP_REGISTER_OPTIMIZER(ccsgd, SGDOptimizer);  // For backward compatibility
 
 
 }  // namespace cpp

--- a/include/mxnet-cpp/optimizer.hpp
+++ b/include/mxnet-cpp/optimizer.hpp
@@ -23,6 +23,11 @@ namespace cpp {
 
 OpMap* Optimizer::op_map_ = new OpMap();
 
+std::map<std::string, OptimizerCreator> OptimizerRegistry::cmap_;
+
+MXNETCPP_REGISTER_OPTIMIZER(sgd, SGDOptimizer);
+MXNETCPP_REGISTER_OPTIMIZER(ccsgd, SGDOptimizer);  // For backward compatibility
+
 Optimizer::~Optimizer() {}
 
 void Optimizer::Update(int index, NDArray weight, NDArray grad, mx_float lr,

--- a/src/OpWrapperGenerator/OpWrapperGenerator.py
+++ b/src/OpWrapperGenerator/OpWrapperGenerator.py
@@ -338,7 +338,7 @@ if __name__ == "__main__":
                  "#include <vector>\n"
                  "#include \"mxnet-cpp/base.h\"\n"
                  "#include \"mxnet-cpp/shape.h\"\n"
-                 "#include \"mxnet-cpp/MxNetCpp.h\"\n"
+                 "#include \"mxnet-cpp/operator.h\"\n"
                  "\n"
                  "namespace mxnet {\n"
                  "namespace cpp {\n"


### PR DESCRIPTION
Move declarations of static variables from h to hpp for optimizer and fix op.h 