### PR TITLE
charRNN upgrade, bug fix

### DIFF
--- a/example/alexnet.cpp
+++ b/example/alexnet.cpp
@@ -296,5 +296,6 @@ int main(int argc, char const *argv[]) {
   }
   /*don't foget to release the executor*/
   delete exec;
+  MXNotifyShutdown();
   return 0;
 }

--- a/example/charRNN.cpp
+++ b/example/charRNN.cpp
@@ -667,8 +667,8 @@ int main(int argc, char** argv) {
   }
 
   string task = argv[1];
-  bool builtIn = task.find("BuiltIn") > 0;
-  TIME_MAJOR = task.find("TimeMajor") > 0;
+  bool builtIn = task.find("BuiltIn") != string::npos;
+  TIME_MAJOR = task.find("TimeMajor") != string::npos;
   cout << "use BuiltIn cuDNN RNN: " << builtIn << " use data as TimeMajor: " << TIME_MAJOR << endl;
   if (task.find("train") == 0) {
     // this function will generate dictionary file and params file.

--- a/example/charRNN.cpp
+++ b/example/charRNN.cpp
@@ -7,6 +7,7 @@
  */
 
 #pragma warning(disable: 4996)
+#include <cstring>
 #include <iostream>
 #include <fstream>
 #include <unordered_map>
@@ -23,332 +24,318 @@ using namespace std;
 using namespace mxnet::cpp;
 
 struct LSTMState {
-  Symbol C;
-  Symbol h;
+	Symbol C;
+	Symbol h;
 };
 
 struct LSTMParam {
-  Symbol i2h_weight;
-  Symbol i2h_bias;
-  Symbol h2h_weight;
-  Symbol h2h_bias;
+	Symbol i2h_weight;
+	Symbol i2h_bias;
+	Symbol h2h_weight;
+	Symbol h2h_bias;
 };
 
 // LSTM Cell symbol
-LSTMState LSTM(int num_hidden, const Symbol& indata, const LSTMState& prev_state,
-    const LSTMParam& param, int seqidx, int layeridx, mx_float dropout = 0) {
-  auto input = dropout > 0? Dropout(indata, dropout) : indata;
-  auto prefix = string("t") + to_string(seqidx) + "_l" + to_string(layeridx);
-  auto i2h = FullyConnected(prefix + "_i2h", input, param.i2h_weight, param.i2h_bias,
-      num_hidden * 4);
-  auto h2h = FullyConnected(prefix + "_h2h", prev_state.h, param.h2h_weight, param.h2h_bias,
-      num_hidden * 4);
-  auto gates = i2h + h2h;
-  auto slice_gates = SliceChannel(prefix + "_slice", gates, 4);
-  auto in_gate = Activation(slice_gates[0], ActivationActType::sigmoid);
-  auto in_transform = Activation(slice_gates[1], ActivationActType::tanh);
-  auto forget_gate = Activation(slice_gates[2], ActivationActType::sigmoid);
-  auto out_gate = Activation(slice_gates[3], ActivationActType::sigmoid);
+LSTMState LSTM(int num_hidden, const Symbol& indata, const LSTMState& prev_state, const LSTMParam& param, int seqidx, int layeridx, mx_float dropout = 0)
+{
+	auto input = dropout > 0? Dropout(indata, dropout) : indata;
+	auto prefix = string("t") + to_string(seqidx) + "_l" + to_string(layeridx);
+	auto i2h = FullyConnected(prefix + "_i2h", input, param.i2h_weight, param.i2h_bias, num_hidden * 4);
+	auto h2h = FullyConnected(prefix + "_h2h", prev_state.h, param.h2h_weight, param.h2h_bias, num_hidden * 4);
+	auto gates = i2h + h2h;
+	auto slice_gates = SliceChannel(prefix + "_slice", gates, 4);
+	auto in_gate = Activation(slice_gates[0], ActivationActType::sigmoid);
+	auto in_transform = Activation(slice_gates[1], ActivationActType::tanh);
+	auto forget_gate = Activation(slice_gates[2], ActivationActType::sigmoid);
+	auto out_gate = Activation(slice_gates[3], ActivationActType::sigmoid);
 
-  LSTMState state;
-  state.C = (forget_gate * prev_state.C) + (in_gate * in_transform);
-  state.h = out_gate * Activation(state.C, ActivationActType::tanh);
-  return state;
+	LSTMState state;
+	state.C = (forget_gate * prev_state.C) + (in_gate * in_transform);
+	state.h = out_gate * Activation(state.C, ActivationActType::tanh);
+	return state;
 }
 
 Symbol LSTMUnroll(int num_lstm_layer, int sequence_length, int input_dim,
-        int num_hidden, int num_embed, int batch_size, mx_float dropout = 0) {
-  auto data = Symbol::Variable("data");
-  auto embed_weight = Symbol::Variable("embed_weight");
-  auto embed = Embedding("embed", data, embed_weight, input_dim, num_embed);
-  auto wordvec = SliceChannel(embed, sequence_length, 1, true);
+        int num_hidden, int num_embed, int batch_size, mx_float dropout = 0)
+{
+	auto data = Symbol::Variable("data");
+	auto embed_weight = Symbol::Variable("embed_weight");
+	auto embed = Embedding("embed", data, embed_weight, input_dim, num_embed);
+	auto wordvec = SliceChannel(embed, sequence_length, 1, true);
 
-  vector<LSTMState> last_states;
-  vector<LSTMParam> param_cells;
-  for (int l = 0; l < num_lstm_layer; l++) {
-    string layer = "l" + to_string(l);
-    LSTMParam param;
-    param.i2h_weight = Symbol::Variable(layer + "_i2h_weight");
-    param.i2h_bias = Symbol::Variable(layer + "_i2h_bias");
-    param.h2h_weight = Symbol::Variable(layer + "_h2h_weight");
-    param.h2h_bias = Symbol::Variable(layer + "_h2h_bias");
-    param_cells.push_back(param);
-    LSTMState state;
-    state.C = Symbol::Variable(layer + "_init_c");
-    state.h = Symbol::Variable(layer + "_init_h");
-    last_states.push_back(state);
-  }
+	vector<LSTMState> last_states;
+	vector<LSTMParam> param_cells;
+	for (int l = 0; l < num_lstm_layer; l++) {
+		string layer = "l" + to_string(l);
+		LSTMParam param;
+		param.i2h_weight = Symbol::Variable(layer + "_i2h_weight");
+		param.i2h_bias = Symbol::Variable(layer + "_i2h_bias");
+		param.h2h_weight = Symbol::Variable(layer + "_h2h_weight");
+		param.h2h_bias = Symbol::Variable(layer + "_h2h_bias");
+		param_cells.push_back(param);
+		LSTMState state;
+		state.C = Symbol::Variable(layer + "_init_c");
+		state.h = Symbol::Variable(layer + "_init_h");
+		last_states.push_back(state);
+	}
 
-  vector<Symbol> hidden_all;
-  for (int i = 0; i < sequence_length; i++) {
-    auto hidden = wordvec[i];
-    for (int layer = 0; layer < num_lstm_layer; layer++) {
-      double dp_ratio = layer == 0? 0 : dropout;
-      auto next_state = LSTM(num_hidden, hidden, last_states[layer], param_cells[layer],
-          i, layer, dp_ratio);
-      hidden = next_state.h;
-      last_states[layer] = next_state;
-    }
+	vector<Symbol> hidden_all;
+	for (int i = 0; i < sequence_length; i++) {
+		auto hidden = wordvec[i];
+		for (int layer = 0; layer < num_lstm_layer; layer++) {
+			double dp_ratio = layer == 0? 0 : dropout;
+			auto next_state = LSTM(num_hidden, hidden, last_states[layer], param_cells[layer], i, layer, dp_ratio);
+			hidden = next_state.h;
+			last_states[layer] = next_state;
+		}
         if (dropout > 0)
             hidden = Dropout(hidden, dropout);
         hidden_all.push_back(hidden);
-  }
+	}
 
-  auto hidden_concat = Concat(hidden_all, hidden_all.size(), 0);
-  auto cls_weight = Symbol::Variable("cls_weight");
-  auto cls_bias = Symbol::Variable("cls_bias");
-  auto pred = FullyConnected("pred", hidden_concat, cls_weight, cls_bias, input_dim);
+	auto hidden_concat = Concat(hidden_all, hidden_all.size(), 0);
+	auto cls_weight = Symbol::Variable("cls_weight");
+	auto cls_bias = Symbol::Variable("cls_bias");
+	auto pred = FullyConnected("pred", hidden_concat, cls_weight, cls_bias, input_dim);
 
-  auto label = Symbol::Variable("softmax_label");
-  label = transpose(label);
-  label = Reshape(label, Shape(0));
-  auto sm = SoftmaxOutput("softmax", pred, label);
-  if (sequence_length == 1) {
-    vector<Symbol> outputs = { sm };
-    for (auto& state : last_states) {
-      outputs.push_back(state.C);
-      outputs.push_back(state.h);
-    }
-    return Symbol::Group(outputs);
-  }
-  return sm;
+	auto label = Symbol::Variable("softmax_label");
+	label = transpose(label);
+	label = Reshape(label, Shape(0));
+	auto sm = SoftmaxOutput("softmax", pred, label);
+	if (sequence_length == 1) {
+		vector<Symbol> outputs = { sm };
+		for (auto& state : last_states) {
+			outputs.push_back(state.C);
+			outputs.push_back(state.h);
+		}
+		return Symbol::Group(outputs);
+	}
+	return sm;
 }
 
 class Shuffler {
-  vector<int> sequence;
- public:
-  explicit Shuffler(int size) : sequence(size) {
-    int* p = sequence.data();
-    for (int i = 0; i < size; i++)
-      *p++ = i;
-  }
-  void shuffle(function<void(int, int)> lambda = nullptr) {
-    random_shuffle(sequence.begin(), sequence.end());
-    int n = 0;
-    if (lambda != nullptr)
-      for (int i : sequence)
-        lambda(n++, i);
-  }
-  const int* data() {
-    return sequence.data();
-  }
+	vector<int> sequence;
+public:
+	explicit Shuffler(int size) : sequence(size) {
+		int* p = sequence.data();
+		for (int i = 0; i < size; i++)
+			*p++ = i;
+	}
+	void shuffle(function<void(int, int)> lambda = nullptr) {
+		random_shuffle(sequence.begin(), sequence.end());
+		int n = 0;
+		if (lambda != nullptr)
+			for (int i : sequence)
+				lambda(n++, i);
+	}
+	const int* data() {
+		return sequence.data();
+	}
 };
 
 class BucketSentenceIter : public DataIter {
-  Shuffler* random;
-  int batch, current, end, sequence_length;
-  Context device;
-  vector<vector<mx_float>> sequences;
-  vector<wchar_t> index2chars;
-  unordered_map<wchar_t, mx_float> charIndices;
+	Shuffler* random;
+	int batch, current, end, sequence_length;
+	Context device;
+	vector<vector<mx_float>> sequences;
+	vector<wchar_t> index2chars;
+	unordered_map<wchar_t, mx_float> charIndices;
 
- public:
-  BucketSentenceIter(string filename, int minibatch, Context context) : batch(minibatch),
-  current(-1), device(context) {
-    auto& content = readContent(filename);
-    buildCharIndex(content);
-    sequences = convertTextToSequences(content, '\n');
+public:
+	BucketSentenceIter(string filename, int minibatch, Context context) : batch(minibatch), current(-1), device(context) {
+		auto& content = readContent(filename);
+		buildCharIndex(content);
+		sequences = convertTextToSequences(content, '\n');
 
-    int N = sequences.size() / batch * batch;  // total used samples
-    sequences.resize(N);
-    sort(sequences.begin(), sequences.end(), [](const vector<mx_float>& a,
-        const vector<mx_float>& b) { return a.size() < b.size(); });
+		int N = sequences.size() / batch * batch; // total used samples
+		sequences.resize(N);
+		sort(sequences.begin(), sequences.end(), [](const vector<mx_float>& a, const vector<mx_float>& b) { return a.size() < b.size(); });
 
-    sequence_length = sequences.back().size();
-    random = new Shuffler(N);
-    // We still can get random results if call Reset() firstly
-//    vector<vector<mx_float>>* target = &sequences;
-//    random->shuffle([target](int n, int i) { (*target)[n].swap((*target)[i]); });
-    end = N / batch;
-  }
-  virtual ~BucketSentenceIter() {
-    delete random;
-  }
+		sequence_length = sequences.back().size();
+		random = new Shuffler(N);
+//		vector<vector<mx_float>>* target = &sequences;
+//		random->shuffle([target](int n, int i) { (*target)[n].swap((*target)[i]); }); //We still can get random results if call Reset() firstly
+		end = N / batch;
+	}
+	virtual ~BucketSentenceIter() {
+		delete random;
+	}
 
-  unsigned int maxSequenceLength() {
-    return sequence_length;
-  }
+	unsigned int maxSequenceLength() {
+		return sequence_length;
+	}
 
-  size_t characterSize() {
-    return charIndices.size();
-  }
+	size_t characterSize() {
+		return charIndices.size();
+	}
 
-  virtual bool Next(void) {
-    return ++current < end;
-  }
-  virtual NDArray GetData(void) {
-    const int* indices = random->data();
-    mx_float *data = new mx_float[sequence_length * batch], *pdata = data;
+	virtual bool Next(void) {
+		return ++current < end;
+	}
+	virtual NDArray GetData(void) {
+		const int* indices = random->data();
+		mx_float *data = new mx_float[sequence_length * batch], *pdata = data;
 
-    for (int i = current * batch, end = i + batch; i < end; i++) {
-      memcpy(pdata, sequences[indices[i]].data(), sequences[indices[i]].size() * sizeof(mx_float));
-      if (sequences[indices[i]].size() < sequence_length)
-        memset(pdata + sequences[indices[i]].size(), 0,
-            (sequence_length - sequences[indices[i]].size()) * sizeof(mx_float));
-      pdata += sequence_length;
-    }
-    NDArray array(Shape(batch, sequence_length), device, false);
-    array.SyncCopyFromCPU(data, batch * sequence_length);
-    return array;
-  }
-  virtual NDArray GetLabel(void) {
-    const int* indices = random->data();
-    mx_float *label = new mx_float[sequence_length * batch], *plabel = label;
+		for (int i = current * batch, end = i + batch; i < end; i++) {
+			memcpy(pdata, sequences[indices[i]].data(), sequences[indices[i]].size() * sizeof(mx_float));
+			if (sequences[indices[i]].size() < sequence_length)
+				memset(pdata + sequences[indices[i]].size(), 0, (sequence_length - sequences[indices[i]].size()) * sizeof(mx_float));
+			pdata += sequence_length;
+		}
+		NDArray array(Shape(batch, sequence_length), device, false);
+		array.SyncCopyFromCPU(data, batch * sequence_length);
+		return array;
+	}
+	virtual NDArray GetLabel(void) {
+		const int* indices = random->data();
+		mx_float *label = new mx_float[sequence_length * batch], *plabel = label;
 
-    for (int i = current * batch, end = i + batch; i < end; i++) {
-      memcpy(plabel, sequences[indices[i]].data() + 1,
-          (sequences[indices[i]].size() - 1) * sizeof(mx_float));
-      memset(plabel + sequences[indices[i]].size() - 1, 0,
-          (sequence_length - sequences[indices[i]].size() + 1) * sizeof(mx_float));
-      plabel += sequence_length;
-    }
-    NDArray array(Shape(batch, sequence_length), device, false);
-    array.SyncCopyFromCPU(label, batch * sequence_length);
-    return array;
-  }
-  virtual int GetPadNum(void) {
-    return sequence_length - sequences[random->data()[current * batch]].size();
-  }
-  virtual std::vector<int> GetIndex(void) {
-    const int* indices = random->data();
-    vector<int> list(indices + current * batch, indices + current * batch + batch);
-    return list;
-  }
-  virtual void BeforeFirst(void) {
-    current = -1;
-    random->shuffle(nullptr);
-  }
+		for (int i = current * batch, end = i + batch; i < end; i++) {
+			memcpy(plabel, sequences[indices[i]].data() + 1, (sequences[indices[i]].size() - 1) * sizeof(mx_float));
+			memset(plabel + sequences[indices[i]].size() - 1, 0, (sequence_length - sequences[indices[i]].size() + 1) * sizeof(mx_float));
+			plabel += sequence_length;
+		}
+		NDArray array(Shape(batch, sequence_length), device, false);
+		array.SyncCopyFromCPU(label, batch * sequence_length);
+		return array;
+	}
+	virtual int GetPadNum(void) {
+		return sequence_length - sequences[random->data()[current * batch]].size();
+	}
+	virtual std::vector<int> GetIndex(void) {
+		const int* indices = random->data();
+		vector<int> list(indices + current * batch, indices + current * batch + batch);
+		return list;
+	}
+	virtual void BeforeFirst(void) {
+		current = -1;
+		random->shuffle(nullptr);
+	}
 
-  wstring readContent(const string file) {
-    wifstream ifs(file, ios::binary);
-    if (ifs) {
-      wostringstream os;
-      os << ifs.rdbuf();
-      return os.str();
-    }
-    return L"";
-  }
+	wstring readContent(const string file) {
+		wifstream ifs(file, ios::binary);
+		if (ifs) {
+			wostringstream os;
+			os << ifs.rdbuf();
+			return os.str();
+		}
+		return L"";
+	}
 
-  void buildCharIndex(const wstring& content) {
-  // This version buildCharIndex() Compatiable with python version char_rnn dictionary
-    int n = 1;
-    charIndices['\0'] = 0;  // padding character
-    index2chars.push_back(0);  // padding character index
-    for (auto c : content)
-      if (charIndices.find(c) == charIndices.end()) {
-        charIndices[c] = n++;
-        index2chars.push_back(c);
-      }
-  }
-//  void buildCharIndex(wstring& content)
-//  {
-//    for (auto c : content)
-//      charIndices[c]++; // char-frequency map; then char-index map
-//    vector<tuple<wchar_t, mx_float>> characters;
-//    for (auto& iter : charIndices)
-//      characters.push_back(make_tuple(iter.first, iter.second));
-//    sort(characters.begin(), characters.end(), [](const tuple<wchar_t, mx_float>& a,
-//      const tuple<wchar_t, mx_float>& b) { return get<1>(a) > get<1>(b); });
-//    mx_float index = 1; //0 is left for zero-padding
-//    index2chars.clear();
-//    index2chars.push_back(0); //zero-padding
-//    for (auto& t : characters) {
-//      charIndices[get<0>(t)] = index++;
-//      index2chars.push_back(get<0>(t));
-//    }
-//  }
+	void buildCharIndex(const wstring& content) { // This version buildCharIndex() Compatiable with python version char_rnn dictionary
+		int n = 1;
+		charIndices['\0'] = 0; // padding character
+		index2chars.push_back(0); // padding character index
+		for (auto c : content)
+			if (charIndices.find(c) == charIndices.end()) {
+				charIndices[c] = n++;
+				index2chars.push_back(c);
+			}
+	}
+//	void buildCharIndex(wstring& content) {
+//		for (auto c : content)
+//			charIndices[c]++; // char-frequency map; then char-index map
+//		vector<tuple<wchar_t, mx_float>> characters;
+//		for (auto& iter : charIndices)
+//			characters.push_back(make_tuple(iter.first, iter.second));
+//		sort(characters.begin(), characters.end(), [](const tuple<wchar_t, mx_float>& a, const tuple<wchar_t, mx_float>& b) { return get<1>(a) > get<1>(b); });
+//		mx_float index = 1; //0 is left for zero-padding
+//		index2chars.clear();
+//		index2chars.push_back(0); //zero-padding
+//		for (auto& t : characters) {
+//			charIndices[get<0>(t)] = index++;
+//			index2chars.push_back(get<0>(t));
+//		}
+//	}
 
-  inline wchar_t character(int i) {
-    return index2chars[i];
-  }
+	inline wchar_t character(int i) {
+		return index2chars[i];
+	}
 
-  inline mx_float index(wchar_t c) {
-    return charIndices[c];
-  }
+	inline mx_float index(wchar_t c) {
+		return charIndices[c];
+	}
 
-  void saveCharIndices(const string file) {
-    wofstream ofs(file, ios::binary);
-    if (ofs) {
-      ofs.write(index2chars.data() + 1, index2chars.size() - 1);
-      ofs.close();
-    }
-  }
+	void saveCharIndices(const string file) {
+		wofstream ofs(file, ios::binary);
+		if (ofs) {
+			ofs.write(index2chars.data() + 1, index2chars.size() - 1);
+			ofs.close();
+		}
+	}
 
-  static tuple<unordered_map<wchar_t, mx_float>, vector<wchar_t>> loadCharIndices(
-      const string file) {
-    wifstream ifs(file, ios::binary);
-    unordered_map<wchar_t, mx_float> map;
-    vector<wchar_t> chars;
-    if (ifs) {
-      wostringstream os;
-      os << ifs.rdbuf();
-      int n = 1;
-      map[L'\0'] = 0;
-      chars.push_back(L'\0');
-      for (auto c : os.str()) {
-        map[c] = (mx_float) n++;
-        chars.push_back(c);
-      }
-    }
-    return {map, chars};
-  }
+	static tuple<unordered_map<wchar_t, mx_float>, vector<wchar_t>> loadCharIndices(const string file) {
+		wifstream ifs(file, ios::binary);
+		unordered_map<wchar_t, mx_float> map;
+		vector<wchar_t> chars;
+		if (ifs) {
+			wostringstream os;
+			os << ifs.rdbuf();
+			int n = 1;
+			map[L'\0'] = 0;
+			chars.push_back(L'\0');
+			for (auto c : os.str()) {
+				map[c] = (mx_float) n++;
+				chars.push_back(c);
+			}
+		}
+		return {map, chars};
+	}
 
-  vector<vector<mx_float>> convertTextToSequences(const wstring& content, wchar_t spliter) {
-    vector<vector<mx_float>> sequences;
-    sequences.push_back(vector<mx_float>());
-    for (auto c : content)
-      if (c == spliter && !sequences.back().empty())
-        sequences.push_back(vector<mx_float>());
-      else
-        sequences.back().push_back(charIndices[c]);
-    return sequences;
-  }
+	vector<vector<mx_float>> convertTextToSequences(const wstring& content, wchar_t spliter) {
+		vector<vector<mx_float>> sequences;
+		sequences.push_back(vector<mx_float>());
+		for (auto c : content)
+			if (c == spliter && !sequences.back().empty())
+				sequences.push_back(vector<mx_float>());
+			else
+				sequences.back().push_back(charIndices[c]);
+		return sequences;
+	}
 };
 
-void OutputPerplexity(NDArray* labels, NDArray* output) {
-  vector<mx_float> charIndices, a;
-  labels->SyncCopyToCPU(&charIndices, 0L);
-  output->SyncCopyToCPU(&a, 0)/*4128*84*/;
-  mx_float loss = 0;
-  int batchSize = labels->GetShape()[0]/*32*/, sequenceLength = labels->GetShape()[1]/*129*/,
-      nSamples = output->GetShape()[0]/*4128*/, vocabSize = output->GetShape()[1]/*84*/;
-  for (int n = 0; n < nSamples; n++) {
-    int row = n % batchSize, column = n / batchSize, labelOffset = column +
-        row * sequenceLength;  // Search based on column storage: labels.T
-    mx_float safe_value = max(1e-10f, a[vocabSize * n +
-                                    static_cast<int>(charIndices[labelOffset])]);
-    loss += -log(safe_value);  // Calculate negative log-likelihood
-  }
-  loss = exp(loss / nSamples);
-  cout << "Train-Perplexity=" << loss << endl;
+void OutputPerplexity(NDArray& labels, NDArray& output)
+{
+	vector<mx_float> charIndices, a;
+	labels.SyncCopyToCPU(&charIndices, 0L);
+	output.SyncCopyToCPU(&a, 0)/*4128*84*/;
+	mx_float loss = 0;
+	int batchSize = labels.GetShape()[0]/*32*/, sequenceLength = labels.GetShape()[1]/*129*/, nSamples = output.GetShape()[0]/*4128*/, vocabSize = output.GetShape()[1]/*84*/;
+	for (int n = 0; n < nSamples; n++) {
+		int row = n % batchSize, column = n / batchSize, labelOffset = column + row * sequenceLength; //Search based on column storage: labels.T
+		mx_float safe_value = max(1e-10f, a[vocabSize * n + int(charIndices[labelOffset])]);
+		loss += -log(safe_value); // Calculate negative log-likelihood
+	}
+	loss = exp(loss / nSamples);
+	cout << "Train-Perplexity=" << loss << endl;
 }
 
-void SaveCheckpoint(const string filepath, Symbol net, Executor* exe) {
-  map<string, NDArray> params;
-  for (auto iter : exe->arg_dict())
-    if (iter.first.find("_init_") == string::npos
-        && iter.first.rfind("data") != iter.first.length() - 4
-        && iter.first.rfind("label") != iter.first.length() - 5)
-      params.insert({"arg:" + iter.first, iter.second});
-  for (auto iter : exe->aux_dict())
-      params.insert({"aux:" + iter.first, iter.second});
-  NDArray::Save(filepath, params);
+void SaveCheckpoint(const string filepath, Symbol net, Executor* exe)
+{
+	map<string, NDArray> params;
+	for (auto iter : exe->arg_dict())
+		if (iter.first.find("_init_") == string::npos && iter.first.rfind("data") != iter.first.length() - 4 && iter.first.rfind("label") != iter.first.length() - 5)
+			params.insert({"arg:" + iter.first, iter.second});
+	for (auto iter : exe->aux_dict())
+			params.insert({"aux:" + iter.first, iter.second});
+	NDArray::Save(filepath, params);
 }
 
-void LoadCheckpoint(const string filepath, Executor* exe) {
-  map<std::string, NDArray> params = NDArray::LoadToMap(filepath);
-  for (auto iter : params) {
-    string type = iter.first.substr(0, 4);
-    string name = iter.first.substr(4);
-    NDArray target;
-    if (type == "arg:")
-      target = exe->arg_dict()[name];
-    else if (type == "aux:")
-      target = exe->aux_dict()[name];
-    else
-      continue;
-    iter.second.CopyTo(&target);
-  }
+void LoadCheckpoint(const string filepath, Executor* exe)
+{
+	map<std::string, NDArray> params = NDArray::LoadToMap(filepath);
+	for (auto iter : params) {
+		string type = iter.first.substr(0, 4);
+		string name = iter.first.substr(4);
+		NDArray target;
+		if (type == "arg:")
+			target = exe->arg_dict()[name];
+		else if (type == "aux:")
+			target = exe->aux_dict()[name];
+		else
+			continue;
+		iter.second.CopyTo(&target);
+	}
 }
 
 int input_dim = 0;/*84*/
@@ -357,154 +344,146 @@ int num_embed = 256;
 int num_lstm_layer = 3;
 int num_hidden = 512;
 mx_float dropout = 0.2;
-void train(const string file, int batch_size, int max_epoch) {
-  Context device(DeviceType::kGPU, 0);
-  BucketSentenceIter dataIter(file, batch_size, device);
-  string prefix = file.substr(0, file.rfind("."));
-  dataIter.saveCharIndices(prefix + ".dictionary");
+void train(const string file, int batch_size, int max_epoch)
+{
+	Context device(DeviceType::kGPU, 0);
+	BucketSentenceIter dataIter(file, batch_size, device);
+	string prefix = file.substr(0, file.rfind("."));
+	dataIter.saveCharIndices(prefix + ".dictionary");
 
-  input_dim = static_cast<int>(dataIter.characterSize());
-  sequence_length_max = dataIter.maxSequenceLength();
+	input_dim = (int) dataIter.characterSize();
+	sequence_length_max = dataIter.maxSequenceLength();
 
-  auto RNN = LSTMUnroll(num_lstm_layer, sequence_length_max, input_dim, num_hidden,
-      num_embed, batch_size, dropout);
-  map<string, NDArray> args_map;
-  args_map["data"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
-  args_map["softmax_label"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
-  for (int i = 0; i < num_lstm_layer; i++) {
-    string key = "l" + to_string(i) + "_init_";
-    args_map[key + "c"] = NDArray(Shape(batch_size, num_hidden), device, false);
-    args_map[key + "h"] = NDArray(Shape(batch_size, num_hidden), device, false);
-  }
-  vector<mx_float> zeros(batch_size * num_hidden, 0);
-  // RNN.SimpleBind(device, args_map, {}, {{"data", kNullOp}});
-  Executor* exe = RNN.SimpleBind(device, args_map);
+	auto RNN = LSTMUnroll(num_lstm_layer, sequence_length_max, input_dim, num_hidden, num_embed, batch_size, dropout);
+	map<string, NDArray> args_map;
+	args_map["data"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
+	args_map["softmax_label"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
+	for (int i = 0; i < num_lstm_layer; i++) {
+		string key = "l" + to_string(i) + "_init_";
+		args_map[key + "c"] = NDArray(Shape(batch_size, num_hidden), device, false);
+		args_map[key + "h"] = NDArray(Shape(batch_size, num_hidden), device, false);
+	}
+	vector<mx_float> zeros(batch_size * num_hidden, 0);
+	Executor* exe = RNN.SimpleBind(device, args_map); // RNN.SimpleBind(device, args_map, {}, {{"data", kNullOp}});
 
-  Xavier xavier = Xavier(Xavier::gaussian, Xavier::in, 2.34);
-  for (auto &arg : exe->arg_dict())
-    xavier(arg.first, &arg.second);
+	Xavier xavier = Xavier(Xavier::gaussian, Xavier::in, 2.34);
+	for (auto &arg : exe->arg_dict())
+		xavier(arg.first, &arg.second);
 
-  mx_float learning_rate = 0.0002;
-  mx_float weight_decay = 0.000002;
-  Optimizer* opt = OptimizerRegistry::Find("ccsgd");
-//  opt->SetParam("momentum", 0.9)->SetParam("rescale_grad", 1.0 / batch_size)
-//  ->SetParam("clip_gradient", 10);
+	mx_float learning_rate = 0.0002;
+	mx_float weight_decay = 0.000002;
+	Optimizer* opt = OptimizerRegistry::Find("ccsgd");
+//	opt->SetParam("momentum", 0.9)->SetParam("rescale_grad", 1.0 / batch_size)->SetParam("clip_gradient", 10);
+	char filepath[256];
 
-  for (int epoch = 0; epoch < max_epoch; ++epoch) {
-    dataIter.Reset();
-    auto tic = chrono::system_clock::now();
-    while (dataIter.Next()) {
-      auto data_batch = dataIter.GetDataBatch();
-      data_batch.data.CopyTo(&exe->arg_dict()["data"]);
-      data_batch.label.CopyTo(&exe->arg_dict()["softmax_label"]);
-      for (int l = 0; l < num_lstm_layer; l++) {
-        string key = "l" + to_string(l) + "_init_";
-        exe->arg_dict()[key + "c"].SyncCopyFromCPU(zeros);
-        exe->arg_dict()[key + "h"].SyncCopyFromCPU(zeros);
-      }
-      NDArray::WaitAll();
+	for (int epoch = 0; epoch < max_epoch; ++epoch) {
+		dataIter.Reset();
+		auto tic = chrono::system_clock::now();
+		while (dataIter.Next()) {
+			auto data_batch = dataIter.GetDataBatch();
+			data_batch.data.CopyTo(&exe->arg_dict()["data"]);
+			data_batch.label.CopyTo(&exe->arg_dict()["softmax_label"]);
+			for (int l = 0; l < num_lstm_layer; l++) {
+				string key = "l" + to_string(l) + "_init_";
+				exe->arg_dict()[key + "c"].SyncCopyFromCPU(zeros);
+				exe->arg_dict()[key + "h"].SyncCopyFromCPU(zeros);
+			}
+			NDArray::WaitAll();
 
-      exe->Forward(true);
-      exe->Backward();
-      exe->UpdateAll(opt, learning_rate, weight_decay);
-      NDArray::WaitAll();
-    }
-    auto toc = chrono::system_clock::now();
-    cout << "Epoch[" << epoch << "] Time Cost:" <<
-        chrono::duration_cast<chrono::seconds>(toc - tic).count() << " seconds ";
-    OutputPerplexity(&exe->arg_dict()["softmax_label"], &exe->outputs[0]);
-    string filepath = prefix + "-" + to_string(epoch + 1) + "";
-    SaveCheckpoint(filepath, RNN, exe);
-  }
+			exe->Forward(true);
+			exe->Backward();
+			exe->UpdateAll(opt, learning_rate, weight_decay);
+			NDArray::WaitAll();
+		}
+		auto toc = chrono::system_clock::now();
+		cout << "Epoch[" << epoch << "] Time Cost:" << chrono::duration_cast<chrono::seconds>(toc - tic).count() << " seconds ";
+		OutputPerplexity(exe->arg_dict()["softmax_label"], exe->outputs[0]);
+		sprintf(filepath, "%s-%04d.params", prefix.c_str(), epoch + 1);
+		SaveCheckpoint(filepath, RNN, exe);
+	}
 }
 
-void predict(wstring* text, int sequence_length, const string param_file,
-    const string dictionary_file) {
-  Context device(DeviceType::kGPU, 0);
-  auto results = BucketSentenceIter::loadCharIndices(dictionary_file);
-  auto dictionary = get<0>(results);
-  auto charIndices = get<1>(results);
-  input_dim = static_cast<int>(charIndices.size());
-  auto RNN = LSTMUnroll(num_lstm_layer, 1, input_dim, num_hidden, num_embed, 1, 0);
+void predict(wstring& text, int sequence_length, const string param_file, const string dictionary_file)
+{
+	Context device(DeviceType::kGPU, 0);
+	auto results = BucketSentenceIter::loadCharIndices(dictionary_file);
+	auto dictionary = get<0>(results);
+	auto charIndices = get<1>(results);
+	input_dim = (int) charIndices.size();
+	auto RNN = LSTMUnroll(num_lstm_layer, 1, input_dim, num_hidden, num_embed, 1, 0);
 
-  map<string, NDArray> args_map;
-  args_map["data"] = NDArray(Shape(1, 1), device, false);
-  args_map["softmax_label"] = NDArray(Shape(1, 1), device, false);
-  vector<mx_float> zeros(num_hidden, 0);
-  for (int l = 0; l < num_lstm_layer; l++) {
-    string key = "l" + to_string(l) + "_init_";
-    args_map[key + "c"] = NDArray(Shape(1, num_hidden), device, false);
-    args_map[key + "h"] = NDArray(Shape(1, num_hidden), device, false);
-    args_map[key + "c"].SyncCopyFromCPU(zeros);
-    args_map[key + "h"].SyncCopyFromCPU(zeros);
-  }
-  Executor* exe = RNN.SimpleBind(device, args_map);
-  LoadCheckpoint(param_file, exe);
+	map<string, NDArray> args_map;
+	args_map["data"] = NDArray(Shape(1, 1), device, false);
+	args_map["softmax_label"] = NDArray(Shape(1, 1), device, false);
+	vector<mx_float> zeros(num_hidden, 0);
+	for (int l = 0; l < num_lstm_layer; l++) {
+		string key = "l" + to_string(l) + "_init_";
+		args_map[key + "c"] = NDArray(Shape(1, num_hidden), device, false);
+		args_map[key + "h"] = NDArray(Shape(1, num_hidden), device, false);
+		args_map[key + "c"].SyncCopyFromCPU(zeros);
+		args_map[key + "h"].SyncCopyFromCPU(zeros);
+	}
+	Executor* exe = RNN.SimpleBind(device, args_map);
+	LoadCheckpoint(param_file, exe);
 
-  mx_float index;
-  wchar_t next;
-  vector<mx_float> softmax;
-  softmax.resize(input_dim);
-  for (auto c : *text) {
-    exe->arg_dict()["data"].SyncCopyFromCPU(&dictionary[c], 1);
-    exe->Forward(false);
+	mx_float index;
+	wchar_t next;
+	vector<mx_float> softmax;
+	softmax.resize(input_dim);
+	for (auto c : text) {
+		exe->arg_dict()["data"].SyncCopyFromCPU(&dictionary[c], 1);
+		exe->Forward(false);
 
-    exe->outputs[0].SyncCopyToCPU(softmax.data(), input_dim);
-    for (int l = 0; l < num_lstm_layer; l++) {
-      string key = "l" + to_string(l) + "_init_";
-      exe->outputs[l * 2 + 1].CopyTo(&args_map[key + "c"]);
-      exe->outputs[l * 2 + 2].CopyTo(&args_map[key + "h"]);
-    }
+		exe->outputs[0].SyncCopyToCPU(softmax.data(), input_dim);
+		for (int l = 0; l < num_lstm_layer; l++) {
+			string key = "l" + to_string(l) + "_init_";
+			exe->outputs[l * 2 + 1].CopyTo(&args_map[key + "c"]);
+			exe->outputs[l * 2 + 2].CopyTo(&args_map[key + "h"]);
+		}
 
-    size_t n = max_element(softmax.begin(), softmax.end()) - softmax.begin();
-    index = (mx_float) n;
-    next = charIndices[n];
-  }
-  text->push_back(next);
+		size_t n = max_element(softmax.begin(), softmax.end()) - softmax.begin();
+		index = (mx_float) n;
+		next = charIndices[n];
+	}
+	text.push_back(next);
 
-  for (int i = 0; i < sequence_length; i++) {
-    exe->arg_dict()["data"].SyncCopyFromCPU(&index, 1);
-    exe->Forward(false);
+	for (int i = 0; i < sequence_length; i++) {
+		exe->arg_dict()["data"].SyncCopyFromCPU(&index, 1);
+		exe->Forward(false);
 
-    exe->outputs[0].SyncCopyToCPU(softmax.data(), input_dim);
-    for (int l = 0; l < num_lstm_layer; l++) {
-      string key = "l" + to_string(l) + "_init_";
-      exe->outputs[l * 2 + 1].CopyTo(&args_map[key + "c"]);
-      exe->outputs[l * 2 + 2].CopyTo(&args_map[key + "h"]);
-    }
+		exe->outputs[0].SyncCopyToCPU(softmax.data(), input_dim);
+		for (int l = 0; l < num_lstm_layer; l++) {
+			string key = "l" + to_string(l) + "_init_";
+			exe->outputs[l * 2 + 1].CopyTo(&args_map[key + "c"]);
+			exe->outputs[l * 2 + 2].CopyTo(&args_map[key + "h"]);
+		}
 
-    size_t n = max_element(softmax.begin(), softmax.end()) - softmax.begin();
-    index = (mx_float) n;
-    next = charIndices[n];
-    text->push_back(next);
-  }
+		size_t n = max_element(softmax.begin(), softmax.end()) - softmax.begin();
+		index = (mx_float) n;
+		next = charIndices[n];
+		text.push_back(next);
+	}
 }
 
-int main(int argc, char** argv) {
-  if (argc < 5) {
-    cout << "Usage for training: charRNN train {corpus file} {batch size} {max epoch}" << endl;
-    cout <<
-    "Usage for prediction: charRNN predict {params file} {dictionary file} {beginning of text}"
-    << endl;
-    return 0;
-  }
+int main(int argc, char** argv)
+{
+	if (argc < 5) {
+		cout << "Usage for training: charRNN train {corpus file} {batch size} {max epoch}" << endl;
+		cout << "Usage for prediction: charRNN predict {params file} {dictionary file} {beginning of text}" << endl;
+		return 0;
+	}
 
-  string task = argv[1];
-  if (task == "train") {
-    // this function will generate dictionary file and params file.
-    train(argv[2], atoi(argv[3]), atoi(argv[4]));
-  } else if (task == "predict") {
-    wstring text;  // = L"If there is anyone out there who still doubts ";
-    // Considering of extending to Chinese samples in future, use wchar_t instead of char
-    for (char c : string(argv[4]))
-      text.push_back((wchar_t) c);
-    /*Python version predicts text default to random selecltions. Here I didn't write the random
-    code, always choose the 'best' character. So the text length reduced to 600. Longer size often
-  leads to repeated sentances, since training sequence length is only 129 for obama corpus.*/
-    predict(&text, 600, argv[2], argv[3]);
-    wcout << text << endl;
-  }
+	string task = argv[1];
+	if (task == "train")
+		train(argv[2], atoi(argv[3]), atoi(argv[4])); // this function will generate dictionary file and params file.
+	else if (task == "predict") {
+		wstring text;// = L"If there is anyone out there who still doubts ";
+		for (char c : string(argv[4])) // Considering of extending to Chinese samples in future, use wchar_t instead of char
+			text.push_back((wchar_t) c);
+		predict(text, 600, argv[2], argv[3]); // Python version predicts text default to random selecltions. Here I didn't write the random code, always choose the 'best' character. So the text length reduced to 600. Longer size often leads to repeated sentances, since training sequence length is only 129 for obama corpus.
+		wcout << text << endl;
+	}
 
-  MXNotifyShutdown();
-  return 0;
+	MXNotifyShutdown();
+	return 0;
 }

--- a/example/charRNN.cpp
+++ b/example/charRNN.cpp
@@ -495,6 +495,7 @@ void trainWithBuiltInRNNOp(const string file, int batch_size, int max_epoch)
    num_embed, dropout);
   map<string, NDArray> args_map;
   args_map["data"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
+  // Avoiding SwapAxis, batch_size is of second dimension.
   args_map["LSTM_init_c"] = NDArray(Shape(num_lstm_layer, batch_size, num_hidden), device, false);
   args_map["LSTM_init_h"] = NDArray(Shape(num_lstm_layer, batch_size, num_hidden), device, false);
   args_map["softmax_label"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
@@ -612,8 +613,9 @@ void predictWithBuiltInRNNOp(wstring* ptext, int sequence_length, const string p
   args_map["data"] = NDArray(Shape(1, 1), device, false);
   args_map["softmax_label"] = NDArray(Shape(1, 1), device, false);
   vector<mx_float> zeros(1 * num_lstm_layer * num_hidden, 0);
-  args_map["LSTM_init_c"] = NDArray(Shape(1, num_lstm_layer, num_hidden), device, false);
-  args_map["LSTM_init_h"] = NDArray(Shape(1, num_lstm_layer, num_hidden), device, false);
+  // Avoiding SwapAxis, batch_size=1 is of second dimension.
+  args_map["LSTM_init_c"] = NDArray(Shape(num_lstm_layer, 1, num_hidden), device, false);
+  args_map["LSTM_init_h"] = NDArray(Shape(num_lstm_layer, 1, num_hidden), device, false);
   args_map["LSTM_init_c"].SyncCopyFromCPU(zeros);
   args_map["LSTM_init_h"].SyncCopyFromCPU(zeros);
   Executor* exe = RNN.SimpleBind(device, args_map);

--- a/example/charRNN.cpp
+++ b/example/charRNN.cpp
@@ -142,7 +142,7 @@ Symbol LSTMWithBuiltInRNNOp(int num_lstm_layer, int sequence_length, int input_d
   // We need not do the SwapAxis op as python version does. Direct and better performance in C++!
   auto rnn_h_init = Symbol::Variable("LSTM_init_h");
   auto rnn_c_init = Symbol::Variable("LSTM_init_c");
-  auto rnn_params = Symbol::Variable("LSTM_paramters");  // See explanations near RNNXavier class
+  auto rnn_params = Symbol::Variable("LSTM_parameters");  // See explanations near RNNXavier class
   auto rnn = RNN(embed, rnn_params, rnn_h_init, rnn_c_init, num_hidden, num_lstm_layer,
 		  RNNMode::lstm, false, dropout, isPredict);
 

--- a/example/charRNN.cpp
+++ b/example/charRNN.cpp
@@ -4,8 +4,10 @@
  * The code implements C++ version charRNN for mxnet\example\rnn\char-rnn.ipynb with MXNet.cpp API.
  * The generated params file is compatiable with python version.
  * train() and predict() has been verified with original data samples.
- * 2017/1/23: add faster version charRNN based on built-in cuDNN RNN operator.
- * Support time major computation graph, although no substantial performance difference.
+ * 2017/1/23:
+ * Add faster version charRNN based on built-in cuDNN RNN operator, 10 times faster.
+ * Add time major computation graph, although no substantial performance difference.
+ * Support continuing training from last params file.
  * Rename params file epoch number starts from zero.
  */
 

--- a/example/charRNN.cpp
+++ b/example/charRNN.cpp
@@ -129,7 +129,7 @@ Symbol LSTMWithBuiltInRNNOp(int num_lstm_layer, int sequence_length, int input_d
   auto label_tm = SwapAxis(label, 0 ,1);
   auto rnn_h_init = SwapAxis(Symbol::Variable("LSTM_init_h"), 0, 1);
   auto rnn_c_init = SwapAxis(Symbol::Variable("LSTM_init_c"), 0, 1);
-  auto rnn_params = Symbol::Variable("LSTM_bias");
+  auto rnn_params = Symbol::Variable("LSTM_paramters");
   auto rnn = RNN(embed_tm, rnn_params, rnn_h_init, rnn_c_init, num_hidden, num_lstm_layer, 
   RNNMode::lstm, false, dropout, (sequence_length == 1));
 
@@ -449,6 +449,17 @@ void train(const string file, int batch_size, int max_epoch) {
   }
 }
 
+class RNNXavier : public Xavier {
+ public:
+  RNNXavier(RandType rand_type = gaussian, FactorType factor_type = avg,
+    float magnitude = 3) : Xavier(rand_type, factor_type, magnitude) {
+  }
+ protected:
+  virtual void InitDefault(NDArray* arr) {
+	  Xavier::InitWeight(arr);
+  }
+};
+
 void trainWithBuiltInRNNOp(const string file, int batch_size, int max_epoch)
 {
   Context device(DeviceType::kGPU, 0);
@@ -469,7 +480,7 @@ void trainWithBuiltInRNNOp(const string file, int batch_size, int max_epoch)
   vector<mx_float> zeros(batch_size * num_lstm_layer * num_hidden, 0);
   Executor* exe = RNN.SimpleBind(device, args_map);
 
-  Xavier xavier = Xavier(Xavier::gaussian, Xavier::in, 2.34);
+  RNNXavier xavier = RNNXavier(Xavier::gaussian, Xavier::in, 2.34);
   for (auto &arg : exe->arg_dict())
     xavier(arg.first, &arg.second);
 

--- a/example/charRNN.cpp
+++ b/example/charRNN.cpp
@@ -127,8 +127,7 @@ Symbol LSTMUnroll(int num_lstm_layer, int sequence_length, int input_dim,
 
 // Currently mxnet GPU version RNN operator is implemented via *fast* NVIDIA cuDNN.
 Symbol LSTMWithBuiltInRNNOp(int num_lstm_layer, int sequence_length, int input_dim,
- int num_hidden, int num_embed, mx_float dropout = 0)
-{
+ int num_hidden, int num_embed, mx_float dropout = 0) {
   auto isTrain = sequence_length > 1;
   auto data = Symbol::Variable("data");
   if (TIME_MAJOR && isTrain)
@@ -438,8 +437,7 @@ void train(const string file, int batch_size, int max_epoch, int start_epoch) {
     Xavier xavier = Xavier(Xavier::gaussian, Xavier::in, 2.34);
     for (auto &arg : exe->arg_dict())
       xavier(arg.first, &arg.second);
-  }
-  else {
+  } else {
     LoadCheckpoint(prefix + "-" + to_string(start_epoch) + ".params", exe);
   }
   start_epoch++;
@@ -495,14 +493,13 @@ class RNNXavier : public Xavier {
   }
 };
 
-void trainWithBuiltInRNNOp(const string file, int batch_size, int max_epoch, int start_epoch)
-{
+void trainWithBuiltInRNNOp(const string file, int batch_size, int max_epoch, int start_epoch) {
   Context device(DeviceType::kGPU, 0);
   BucketSentenceIter dataIter(file, batch_size, device);
   string prefix = file.substr(0, file.rfind("."));
   dataIter.saveCharIndices(prefix + ".dictionary");
 
-  input_dim = (int) dataIter.characterSize();
+  input_dim = static_cast<int>(dataIter.characterSize());
   sequence_length_max = dataIter.maxSequenceLength();
 
   auto RNN = LSTMWithBuiltInRNNOp(num_lstm_layer, sequence_length_max, input_dim, num_hidden,
@@ -520,8 +517,7 @@ void trainWithBuiltInRNNOp(const string file, int batch_size, int max_epoch, int
     RNNXavier xavier = RNNXavier(Xavier::gaussian, Xavier::in, 2.34);
     for (auto &arg : exe->arg_dict())
       xavier(arg.first, &arg.second);
-  }
-  else {
+  } else {
     LoadCheckpoint(prefix + "-" + to_string(start_epoch) + ".params", exe);
   }
   start_epoch++;
@@ -620,13 +616,12 @@ void predict(wstring* ptext, int sequence_length, const string param_file,
 }
 
 void predictWithBuiltInRNNOp(wstring* ptext, int sequence_length, const string param_file,
-  const string dictionary_file)
-{
+  const string dictionary_file) {
   Context device(DeviceType::kGPU, 0);
   auto results = BucketSentenceIter::loadCharIndices(dictionary_file);
   auto dictionary = get<0>(results);
   auto charIndices = get<1>(results);
-  input_dim = (int) charIndices.size();
+  input_dim = static_cast<int>(charIndices.size());
   auto RNN = LSTMWithBuiltInRNNOp(num_lstm_layer, 1, input_dim, num_hidden, num_embed, 0);
 
   map<string, NDArray> args_map;
@@ -676,15 +671,12 @@ void predictWithBuiltInRNNOp(wstring* ptext, int sequence_length, const string p
 
 int main(int argc, char** argv) {
   if (argc < 5) {
-    cout <<
-    "Usage for training: charRNN train[BuiltIn][TimeMajor] {corpus file} {batch size} {max epoch} [{starting epoch}]"
-    << endl;
-    cout <<
-    "Usage for prediction: charRNN predict[BuiltIn][TimeMajor] {params file} {dictionary file} {beginning of text}"
-    << endl;
-    cout <<
-    "Note: The {params file} of train/trainBuiltIn/trainTimeMajor/trainBuiltInTimeMajor are not compatible with each other."
-    << endl;
+    cout << "Usage for training: charRNN train[BuiltIn][TimeMajor] {corpus file}"
+    		" {batch size} {max epoch} [{starting epoch}]" << endl;
+    cout <<"Usage for prediction: charRNN predict[BuiltIn][TimeMajor] {params file}"
+    		" {dictionary file} {beginning of text}" << endl;
+    cout <<"Note: The {params file} of train/trainBuiltIn/trainTimeMajor/trainBuiltInTimeMajor"
+    		" are not compatible with each other." << endl;
     return 0;
   }
 
@@ -702,9 +694,8 @@ int main(int argc, char** argv) {
       trainWithBuiltInRNNOp(argv[2], atoi(argv[3]), atoi(argv[4]), start_epoch);
     else
       train(argv[2], atoi(argv[3]), atoi(argv[4]), start_epoch);  // ditto
-  }
-  else if (task.find("predict") == 0) {
-    wstring text;// = L"If there is anyone out there who still doubts ";
+  } else if (task.find("predict") == 0) {
+    wstring text;  // = L"If there is anyone out there who still doubts ";
     // Considering of extending to Chinese samples in future, use wchar_t instead of char
     for (char c : string(argv[4]))
       text.push_back((wchar_t) c);

--- a/example/charRNN.cpp
+++ b/example/charRNN.cpp
@@ -672,11 +672,11 @@ void predictWithBuiltInRNNOp(wstring* ptext, int sequence_length, const string p
 int main(int argc, char** argv) {
   if (argc < 5) {
     cout << "Usage for training: charRNN train[BuiltIn][TimeMajor] {corpus file}"
-    		" {batch size} {max epoch} [{starting epoch}]" << endl;
+            " {batch size} {max epoch} [{starting epoch}]" << endl;
     cout <<"Usage for prediction: charRNN predict[BuiltIn][TimeMajor] {params file}"
-    		" {dictionary file} {beginning of text}" << endl;
+            " {dictionary file} {beginning of text}" << endl;
     cout <<"Note: The {params file} of train/trainBuiltIn/trainTimeMajor/trainBuiltInTimeMajor"
-    		" are not compatible with each other." << endl;
+            " are not compatible with each other." << endl;
     return 0;
   }
 

--- a/example/charRNN.cpp
+++ b/example/charRNN.cpp
@@ -69,7 +69,7 @@ Symbol LSTMUnroll(int num_lstm_layer, int sequence_length, int input_dim,
   auto isTrain = sequence_length > 1;
   auto data = Symbol::Variable("data");
   if (TIME_MAJOR && isTrain)
-	  data = transpose(data);
+    data = transpose(data);
   auto embed_weight = Symbol::Variable("embed_weight");
   auto embed = Embedding("embed", data, embed_weight, input_dim, num_embed);
   auto wordvec = isTrain? SliceChannel(embed, sequence_length, TIME_MAJOR? 0 : 1, true) : embed;
@@ -132,7 +132,7 @@ Symbol LSTMWithBuiltInRNNOp(int num_lstm_layer, int sequence_length, int input_d
   auto isTrain = sequence_length > 1;
   auto data = Symbol::Variable("data");
   if (TIME_MAJOR && isTrain)
-	  data = transpose(data);
+    data = transpose(data);
 
   auto embed_weight = Symbol::Variable("embed_weight");
   auto embed = Embedding("embed", data, embed_weight, input_dim, num_embed);
@@ -140,14 +140,14 @@ Symbol LSTMWithBuiltInRNNOp(int num_lstm_layer, int sequence_length, int input_d
   label = transpose(label);
   label = Reshape(label, Shape(), false, Shape(-1));  // FullyConnected requires one dimension
   if (!TIME_MAJOR && isTrain)
-	  embed = SwapAxis(embed, 0, 1);  // Change to time-major as cuDNN requires
+    embed = SwapAxis(embed, 0, 1);  // Change to time-major as cuDNN requires
 
   // We need not do the SwapAxis op as python version does. Direct and better performance in C++!
   auto rnn_h_init = Symbol::Variable("LSTM_init_h");
   auto rnn_c_init = Symbol::Variable("LSTM_init_c");
   auto rnn_params = Symbol::Variable("LSTM_parameters");  // See explanations near RNNXavier class
   auto rnn = RNN(embed, rnn_params, rnn_h_init, rnn_c_init, num_hidden, num_lstm_layer,
-		  RNNMode::lstm, false, dropout, !isTrain);
+      RNNMode::lstm, false, dropout, !isTrain);
   auto hidden = Reshape(rnn[0], Shape(), false, Shape(-1, num_hidden));
 
   auto cls_weight = Symbol::Variable("cls_weight");
@@ -166,7 +166,7 @@ Symbol LSTMWithBuiltInRNNOp(int num_lstm_layer, int sequence_length, int input_d
     return sm;
   else
     return Symbol::Group({ sm, rnn[1/*RNNOpOutputs::kStateOut=1*/],
-	  rnn[2/*RNNOpOutputs::kStateCellOut=2*/] });
+    rnn[2/*RNNOpOutputs::kStateCellOut=2*/] });
 }
 
 class Shuffler {
@@ -440,7 +440,7 @@ void train(const string file, int batch_size, int max_epoch, int start_epoch) {
       xavier(arg.first, &arg.second);
   }
   else {
-	  LoadCheckpoint(prefix + "-" + to_string(start_epoch) + ".params", exe);
+    LoadCheckpoint(prefix + "-" + to_string(start_epoch) + ".params", exe);
   }
   start_epoch++;
 
@@ -506,7 +506,7 @@ void trainWithBuiltInRNNOp(const string file, int batch_size, int max_epoch, int
   sequence_length_max = dataIter.maxSequenceLength();
 
   auto RNN = LSTMWithBuiltInRNNOp(num_lstm_layer, sequence_length_max, input_dim, num_hidden,
-   num_embed, dropout);
+      num_embed, dropout);
   map<string, NDArray> args_map;
   args_map["data"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
   // Avoiding SwapAxis, batch_size is of second dimension.
@@ -522,7 +522,7 @@ void trainWithBuiltInRNNOp(const string file, int batch_size, int max_epoch, int
       xavier(arg.first, &arg.second);
   }
   else {
-	  LoadCheckpoint(prefix + "-" + to_string(start_epoch) + ".params", exe);
+    LoadCheckpoint(prefix + "-" + to_string(start_epoch) + ".params", exe);
   }
   start_epoch++;
 
@@ -697,7 +697,7 @@ int main(int argc, char** argv) {
     cout << "train batch size:      " << argv[3] << endl
            << "train max epoch:       " << argv[4] << endl;
     int start_epoch = argc > 5? atoi(argv[5]) : -1;
-	// this function will generate dictionary file and params file.
+    // this function will generate dictionary file and params file.
     if (builtIn)
       trainWithBuiltInRNNOp(argv[2], atoi(argv[3]), atoi(argv[4]), start_epoch);
     else

--- a/example/charRNN.cpp
+++ b/example/charRNN.cpp
@@ -669,6 +669,7 @@ int main(int argc, char** argv) {
   string task = argv[1];
   bool builtIn = task.find("BuiltIn") > 0;
   TIME_MAJOR = task.find("TimeMajor") > 0;
+  cout << "use BuiltIn cuDNN RNN: " << builtIn << " use data as TimeMajor: " << TIME_MAJOR << endl;
   if (task.find("train") == 0) {
     // this function will generate dictionary file and params file.
     if (builtIn)

--- a/example/charRNN.cpp
+++ b/example/charRNN.cpp
@@ -61,7 +61,7 @@ LSTMState LSTM(int num_hidden, const Symbol& indata, const LSTMState& prev_state
 }
 
 Symbol LSTMUnroll(int num_lstm_layer, int sequence_length, int input_dim,
-        int num_hidden, int num_embed, int batch_size, mx_float dropout = 0) {
+        int num_hidden, int num_embed, mx_float dropout = 0) {
   auto isPredict = sequence_length == 1;
   auto data = Symbol::Variable("data");
   if (TIME_MAJOR && !isPredict)
@@ -413,7 +413,7 @@ void train(const string file, int batch_size, int max_epoch) {
   sequence_length_max = dataIter.maxSequenceLength();
 
   auto RNN = LSTMUnroll(num_lstm_layer, sequence_length_max, input_dim, num_hidden,
-      num_embed, batch_size, dropout);
+      num_embed, dropout);
   map<string, NDArray> args_map;
   args_map["data"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
   args_map["softmax_label"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
@@ -544,7 +544,7 @@ void predict(wstring* ptext, int sequence_length, const string param_file,
   auto dictionary = get<0>(results);
   auto charIndices = get<1>(results);
   input_dim = static_cast<int>(charIndices.size());
-  auto RNN = LSTMUnroll(num_lstm_layer, 1, input_dim, num_hidden, num_embed, 1, 0);
+  auto RNN = LSTMUnroll(num_lstm_layer, 1, input_dim, num_hidden, num_embed, 0);
 
   map<string, NDArray> args_map;
   args_map["data"] = NDArray(Shape(1, 1), device, false);
@@ -671,9 +671,12 @@ int main(int argc, char** argv) {
   string task = argv[1];
   bool builtIn = task.find("BuiltIn") != string::npos;
   TIME_MAJOR = task.find("TimeMajor") != string::npos;
-  cout << "use BuiltIn cuDNN RNN: " << builtIn << " use data as TimeMajor: " << TIME_MAJOR << endl;
+  cout << "use BuiltIn cuDNN RNN: " << builtIn << endl
+         << "use data as TimeMajor: " << TIME_MAJOR << endl;
   if (task.find("train") == 0) {
-    // this function will generate dictionary file and params file.
+    cout << "train batch size: " << argv[3] << endl
+           << "train max epoch: " << argv[4] << endl;
+	// this function will generate dictionary file and params file.
     if (builtIn)
       trainWithBuiltInRNNOp(argv[2], atoi(argv[3]), atoi(argv[4]));
     else

--- a/example/charRNN.cpp
+++ b/example/charRNN.cpp
@@ -25,116 +25,121 @@ using namespace std;
 using namespace mxnet::cpp;
 
 struct LSTMState {
-	Symbol C;
-	Symbol h;
+  Symbol C;
+  Symbol h;
 };
 
 struct LSTMParam {
-	Symbol i2h_weight;
-	Symbol i2h_bias;
-	Symbol h2h_weight;
-	Symbol h2h_bias;
+  Symbol i2h_weight;
+  Symbol i2h_bias;
+  Symbol h2h_weight;
+  Symbol h2h_bias;
 };
 
 // LSTM Cell symbol
-LSTMState LSTM(int num_hidden, const Symbol& indata, const LSTMState& prev_state, const LSTMParam& param, int seqidx, int layeridx, mx_float dropout = 0)
-{
-	auto input = dropout > 0? Dropout(indata, dropout) : indata;
-	auto prefix = string("t") + to_string(seqidx) + "_l" + to_string(layeridx);
-	auto i2h = FullyConnected(prefix + "_i2h", input, param.i2h_weight, param.i2h_bias, num_hidden * 4);
-	auto h2h = FullyConnected(prefix + "_h2h", prev_state.h, param.h2h_weight, param.h2h_bias, num_hidden * 4);
-	auto gates = i2h + h2h;
-	auto slice_gates = SliceChannel(prefix + "_slice", gates, 4);
-	auto in_gate = Activation(slice_gates[0], ActivationActType::sigmoid);
-	auto in_transform = Activation(slice_gates[1], ActivationActType::tanh);
-	auto forget_gate = Activation(slice_gates[2], ActivationActType::sigmoid);
-	auto out_gate = Activation(slice_gates[3], ActivationActType::sigmoid);
+LSTMState LSTM(int num_hidden, const Symbol& indata, const LSTMState& prev_state,
+    const LSTMParam& param, int seqidx, int layeridx, mx_float dropout = 0) {
+  auto input = dropout > 0? Dropout(indata, dropout) : indata;
+  auto prefix = string("t") + to_string(seqidx) + "_l" + to_string(layeridx);
+  auto i2h = FullyConnected(prefix + "_i2h", input, param.i2h_weight, param.i2h_bias,
+      num_hidden * 4);
+  auto h2h = FullyConnected(prefix + "_h2h", prev_state.h, param.h2h_weight, param.h2h_bias,
+      num_hidden * 4);
+  auto gates = i2h + h2h;
+  auto slice_gates = SliceChannel(prefix + "_slice", gates, 4);
+  auto in_gate = Activation(slice_gates[0], ActivationActType::sigmoid);
+  auto in_transform = Activation(slice_gates[1], ActivationActType::tanh);
+  auto forget_gate = Activation(slice_gates[2], ActivationActType::sigmoid);
+  auto out_gate = Activation(slice_gates[3], ActivationActType::sigmoid);
 
-	LSTMState state;
-	state.C = (forget_gate * prev_state.C) + (in_gate * in_transform);
-	state.h = out_gate * Activation(state.C, ActivationActType::tanh);
-	return state;
+  LSTMState state;
+  state.C = (forget_gate * prev_state.C) + (in_gate * in_transform);
+  state.h = out_gate * Activation(state.C, ActivationActType::tanh);
+  return state;
 }
 
-Symbol LSTMUnroll(int num_lstm_layer, int sequence_length, int input_dim, int num_hidden, int num_embed, mx_float dropout = 0)
-{
-	auto data = Symbol::Variable("data");
-	auto embed_weight = Symbol::Variable("embed_weight");
-	auto embed = Embedding("embed", data, embed_weight, input_dim, num_embed);
-	auto wordvec = SliceChannel(embed, sequence_length, 1, true);
+Symbol LSTMUnroll(int num_lstm_layer, int sequence_length, int input_dim,
+        int num_hidden, int num_embed, int batch_size, mx_float dropout = 0) {
+  auto data = Symbol::Variable("data");
+  auto embed_weight = Symbol::Variable("embed_weight");
+  auto embed = Embedding("embed", data, embed_weight, input_dim, num_embed);
+  auto wordvec = SliceChannel(embed, sequence_length, 1, true);
 
-	vector<LSTMState> last_states;
-	vector<LSTMParam> param_cells;
-	for (int l = 0; l < num_lstm_layer; l++) {
-		string layer = "l" + to_string(l);
-		LSTMParam param;
-		param.i2h_weight = Symbol::Variable(layer + "_i2h_weight");
-		param.i2h_bias = Symbol::Variable(layer + "_i2h_bias");
-		param.h2h_weight = Symbol::Variable(layer + "_h2h_weight");
-		param.h2h_bias = Symbol::Variable(layer + "_h2h_bias");
-		param_cells.push_back(param);
-		LSTMState state;
-		state.C = Symbol::Variable(layer + "_init_c");
-		state.h = Symbol::Variable(layer + "_init_h");
-		last_states.push_back(state);
-	}
+  vector<LSTMState> last_states;
+  vector<LSTMParam> param_cells;
+  for (int l = 0; l < num_lstm_layer; l++) {
+    string layer = "l" + to_string(l);
+    LSTMParam param;
+    param.i2h_weight = Symbol::Variable(layer + "_i2h_weight");
+    param.i2h_bias = Symbol::Variable(layer + "_i2h_bias");
+    param.h2h_weight = Symbol::Variable(layer + "_h2h_weight");
+    param.h2h_bias = Symbol::Variable(layer + "_h2h_bias");
+    param_cells.push_back(param);
+    LSTMState state;
+    state.C = Symbol::Variable(layer + "_init_c");
+    state.h = Symbol::Variable(layer + "_init_h");
+    last_states.push_back(state);
+  }
 
-	vector<Symbol> hidden_all;
-	for (int i = 0; i < sequence_length; i++) {
-		auto hidden = wordvec[i];
-		for (int layer = 0; layer < num_lstm_layer; layer++) {
-			double dp_ratio = layer == 0? 0 : dropout;
-			auto next_state = LSTM(num_hidden, hidden, last_states[layer], param_cells[layer], i, layer, dp_ratio);
-			hidden = next_state.h;
-			last_states[layer] = next_state;
-		}
+  vector<Symbol> hidden_all;
+  for (int i = 0; i < sequence_length; i++) {
+    auto hidden = wordvec[i];
+    for (int layer = 0; layer < num_lstm_layer; layer++) {
+      double dp_ratio = layer == 0? 0 : dropout;
+      auto next_state = LSTM(num_hidden, hidden, last_states[layer], param_cells[layer],
+          i, layer, dp_ratio);
+      hidden = next_state.h;
+      last_states[layer] = next_state;
+    }
         if (dropout > 0)
             hidden = Dropout(hidden, dropout);
         hidden_all.push_back(hidden);
-	}
+  }
 
-	auto hidden_concat = Concat(hidden_all, hidden_all.size(), 0);
-	auto cls_weight = Symbol::Variable("cls_weight");
-	auto cls_bias = Symbol::Variable("cls_bias");
-	auto pred = FullyConnected("pred", hidden_concat, cls_weight, cls_bias, input_dim);
+  auto hidden_concat = Concat(hidden_all, hidden_all.size(), 0);
+  auto cls_weight = Symbol::Variable("cls_weight");
+  auto cls_bias = Symbol::Variable("cls_bias");
+  auto pred = FullyConnected("pred", hidden_concat, cls_weight, cls_bias, input_dim);
 
-	auto label = Symbol::Variable("softmax_label");
-	label = transpose(label);
-	label = Reshape(label, Shape(), false, Shape(-1));  // -1: infer from graph
-	auto sm = SoftmaxOutput("softmax", pred, label);
-	if (sequence_length == 1) {
-		vector<Symbol> outputs = { sm };
-		for (auto& state : last_states) {
-			outputs.push_back(state.C);
-			outputs.push_back(state.h);
-		}
-		return Symbol::Group(outputs);
-	}
-	return sm;
+  auto label = Symbol::Variable("softmax_label");
+  label = transpose(label);
+  label = Reshape(label, Shape(), false, Shape(-1));  // -1: infer from graph
+  auto sm = SoftmaxOutput("softmax", pred, label);
+  if (sequence_length == 1) {
+    vector<Symbol> outputs = { sm };
+    for (auto& state : last_states) {
+      outputs.push_back(state.C);
+      outputs.push_back(state.h);
+    }
+    return Symbol::Group(outputs);
+  }
+  return sm;
 }
 
-Symbol LSTMWithBuiltInRNNOp(int num_lstm_layer, int sequence_length, int input_dim, int num_hidden, int num_embed, mx_float dropout = 0)
+Symbol LSTMWithBuiltInRNNOp(int num_lstm_layer, int sequence_length, int input_dim,
+ int num_hidden, int num_embed, mx_float dropout = 0)
 {
-	auto data = Symbol::Variable("data");
-	auto embed_weight = Symbol::Variable("embed_weight");
-	auto embed = Embedding("embed", data, embed_weight, input_dim, num_embed);
+  auto data = Symbol::Variable("data");
+  auto embed_weight = Symbol::Variable("embed_weight");
+  auto embed = Embedding("embed", data, embed_weight, input_dim, num_embed);
 
-	auto label = Symbol::Variable("softmax_label");
+  auto label = Symbol::Variable("softmax_label");
 
-	auto embed_tm = SwapAxis(embed, 0, 1);
-	auto label_tm = SwapAxis(label, 0 ,1);
-	auto rnn_h_init = SwapAxis(Symbol::Variable("LSTM_init_h"), 0, 1);
-	auto rnn_c_init = SwapAxis(Symbol::Variable("LSTM_init_c"), 0, 1);
-	auto rnn_params = Symbol::Variable("LSTM_bias");
-	auto rnn = RNN(embed_tm, rnn_params, rnn_h_init, rnn_c_init, num_hidden, num_lstm_layer, RNNMode::lstm, false, dropout, (sequence_length == 1));
+  auto embed_tm = SwapAxis(embed, 0, 1);
+  auto label_tm = SwapAxis(label, 0 ,1);
+  auto rnn_h_init = SwapAxis(Symbol::Variable("LSTM_init_h"), 0, 1);
+  auto rnn_c_init = SwapAxis(Symbol::Variable("LSTM_init_c"), 0, 1);
+  auto rnn_params = Symbol::Variable("LSTM_bias");
+  auto rnn = RNN(embed_tm, rnn_params, rnn_h_init, rnn_c_init, num_hidden, num_lstm_layer, 
+  RNNMode::lstm, false, dropout, (sequence_length == 1));
 
     auto hidden = Reshape(rnn, Shape(), false, Shape(-1, num_hidden));
     auto label_cl = Reshape(label_tm, Shape(), false, Shape(-1));
 
-	auto cls_weight = Symbol::Variable("cls_weight");
-	auto cls_bias = Symbol::Variable("cls_bias");
-	auto pred = FullyConnected("pred", hidden, cls_weight, cls_bias, input_dim);
-	auto sm = SoftmaxOutput("softmax", pred, label_cl);
+  auto cls_weight = Symbol::Variable("cls_weight");
+  auto cls_bias = Symbol::Variable("cls_bias");
+  auto pred = FullyConnected("pred", hidden, cls_weight, cls_bias, input_dim);
+  auto sm = SoftmaxOutput("softmax", pred, label_cl);
 
 //    data_names = ['data', 'LSTM_init_h', 'LSTM_init_c']
 //    label_names = ['softmax_label']
@@ -142,228 +147,239 @@ Symbol LSTMWithBuiltInRNNOp(int num_lstm_layer, int sequence_length, int input_d
 }
 
 class Shuffler {
-	vector<int> sequence;
-public:
-	explicit Shuffler(int size) : sequence(size) {
-		int* p = sequence.data();
-		for (int i = 0; i < size; i++)
-			*p++ = i;
-	}
-	void shuffle(function<void(int, int)> lambda = nullptr) {
-		random_shuffle(sequence.begin(), sequence.end());
-		int n = 0;
-		if (lambda != nullptr)
-			for (int i : sequence)
-				lambda(n++, i);
-	}
-	const int* data() {
-		return sequence.data();
-	}
+  vector<int> sequence;
+ public:
+  explicit Shuffler(int size) : sequence(size) {
+    int* p = sequence.data();
+    for (int i = 0; i < size; i++)
+      *p++ = i;
+  }
+  void shuffle(function<void(int, int)> lambda = nullptr) {
+    random_shuffle(sequence.begin(), sequence.end());
+    int n = 0;
+    if (lambda != nullptr)
+      for (int i : sequence)
+        lambda(n++, i);
+  }
+  const int* data() {
+    return sequence.data();
+  }
 };
 
 class BucketSentenceIter : public DataIter {
-	Shuffler* random;
-	int batch, current, end, sequence_length;
-	Context device;
-	vector<vector<mx_float>> sequences;
-	vector<wchar_t> index2chars;
-	unordered_map<wchar_t, mx_float> charIndices;
+  Shuffler* random;
+  int batch, current, end, sequence_length;
+  Context device;
+  vector<vector<mx_float>> sequences;
+  vector<wchar_t> index2chars;
+  unordered_map<wchar_t, mx_float> charIndices;
 
-public:
-	BucketSentenceIter(string filename, int minibatch, Context context) : batch(minibatch), current(-1), device(context) {
-		auto& content = readContent(filename);
-		buildCharIndex(content);
-		sequences = convertTextToSequences(content, '\n');
+ public:
+  BucketSentenceIter(string filename, int minibatch, Context context) : batch(minibatch),
+  current(-1), device(context) {
+    auto& content = readContent(filename);
+    buildCharIndex(content);
+    sequences = convertTextToSequences(content, '\n');
 
-		int N = sequences.size() / batch * batch; // total used samples
-		sequences.resize(N);
-		sort(sequences.begin(), sequences.end(), [](const vector<mx_float>& a, const vector<mx_float>& b) { return a.size() < b.size(); });
+    int N = sequences.size() / batch * batch;  // total used samples
+    sequences.resize(N);
+    sort(sequences.begin(), sequences.end(), [](const vector<mx_float>& a,
+        const vector<mx_float>& b) { return a.size() < b.size(); });
 
-		sequence_length = sequences.back().size();
-		random = new Shuffler(N);
-//		vector<vector<mx_float>>* target = &sequences;
-//		random->shuffle([target](int n, int i) { (*target)[n].swap((*target)[i]); }); //We still can get random results if call Reset() firstly
-		end = N / batch;
-	}
-	virtual ~BucketSentenceIter() {
-		delete random;
-	}
+    sequence_length = sequences.back().size();
+    random = new Shuffler(N);
+    // We still can get random results if call Reset() firstly
+//    vector<vector<mx_float>>* target = &sequences;
+//    random->shuffle([target](int n, int i) { (*target)[n].swap((*target)[i]); });
+    end = N / batch;
+  }
+  virtual ~BucketSentenceIter() {
+    delete random;
+  }
 
-	unsigned int maxSequenceLength() {
-		return sequence_length;
-	}
+  unsigned int maxSequenceLength() {
+    return sequence_length;
+  }
 
-	size_t characterSize() {
-		return charIndices.size();
-	}
+  size_t characterSize() {
+    return charIndices.size();
+  }
 
-	virtual bool Next(void) {
-		return ++current < end;
-	}
-	virtual NDArray GetData(void) {
-		const int* indices = random->data();
-		mx_float *data = new mx_float[sequence_length * batch], *pdata = data;
+  virtual bool Next(void) {
+    return ++current < end;
+  }
+  virtual NDArray GetData(void) {
+    const int* indices = random->data();
+    mx_float *data = new mx_float[sequence_length * batch], *pdata = data;
 
-		for (int i = current * batch, end = i + batch; i < end; i++) {
-			memcpy(pdata, sequences[indices[i]].data(), sequences[indices[i]].size() * sizeof(mx_float));
-			if (sequences[indices[i]].size() < sequence_length)
-				memset(pdata + sequences[indices[i]].size(), 0, (sequence_length - sequences[indices[i]].size()) * sizeof(mx_float));
-			pdata += sequence_length;
-		}
-		NDArray array(Shape(batch, sequence_length), device, false);
-		array.SyncCopyFromCPU(data, batch * sequence_length);
-		return array;
-	}
-	virtual NDArray GetLabel(void) {
-		const int* indices = random->data();
-		mx_float *label = new mx_float[sequence_length * batch], *plabel = label;
+    for (int i = current * batch, end = i + batch; i < end; i++) {
+      memcpy(pdata, sequences[indices[i]].data(), sequences[indices[i]].size() * sizeof(mx_float));
+      if (sequences[indices[i]].size() < sequence_length)
+        memset(pdata + sequences[indices[i]].size(), 0,
+            (sequence_length - sequences[indices[i]].size()) * sizeof(mx_float));
+      pdata += sequence_length;
+    }
+    NDArray array(Shape(batch, sequence_length), device, false);
+    array.SyncCopyFromCPU(data, batch * sequence_length);
+    return array;
+  }
+  virtual NDArray GetLabel(void) {
+    const int* indices = random->data();
+    mx_float *label = new mx_float[sequence_length * batch], *plabel = label;
 
-		for (int i = current * batch, end = i + batch; i < end; i++) {
-			memcpy(plabel, sequences[indices[i]].data() + 1, (sequences[indices[i]].size() - 1) * sizeof(mx_float));
-			memset(plabel + sequences[indices[i]].size() - 1, 0, (sequence_length - sequences[indices[i]].size() + 1) * sizeof(mx_float));
-			plabel += sequence_length;
-		}
-		NDArray array(Shape(batch, sequence_length), device, false);
-		array.SyncCopyFromCPU(label, batch * sequence_length);
-		return array;
-	}
-	virtual int GetPadNum(void) {
-		return sequence_length - sequences[random->data()[current * batch]].size();
-	}
-	virtual std::vector<int> GetIndex(void) {
-		const int* indices = random->data();
-		vector<int> list(indices + current * batch, indices + current * batch + batch);
-		return list;
-	}
-	virtual void BeforeFirst(void) {
-		current = -1;
-		random->shuffle(nullptr);
-	}
+    for (int i = current * batch, end = i + batch; i < end; i++) {
+      memcpy(plabel, sequences[indices[i]].data() + 1,
+          (sequences[indices[i]].size() - 1) * sizeof(mx_float));
+      memset(plabel + sequences[indices[i]].size() - 1, 0,
+          (sequence_length - sequences[indices[i]].size() + 1) * sizeof(mx_float));
+      plabel += sequence_length;
+    }
+    NDArray array(Shape(batch, sequence_length), device, false);
+    array.SyncCopyFromCPU(label, batch * sequence_length);
+    return array;
+  }
+  virtual int GetPadNum(void) {
+    return sequence_length - sequences[random->data()[current * batch]].size();
+  }
+  virtual std::vector<int> GetIndex(void) {
+    const int* indices = random->data();
+    vector<int> list(indices + current * batch, indices + current * batch + batch);
+    return list;
+  }
+  virtual void BeforeFirst(void) {
+    current = -1;
+    random->shuffle(nullptr);
+  }
 
-	wstring readContent(const string file) {
-		wifstream ifs(file, ios::binary);
-		if (ifs) {
-			wostringstream os;
-			os << ifs.rdbuf();
-			return os.str();
-		}
-		return L"";
-	}
+  wstring readContent(const string file) {
+    wifstream ifs(file, ios::binary);
+    if (ifs) {
+      wostringstream os;
+      os << ifs.rdbuf();
+      return os.str();
+    }
+    return L"";
+  }
 
-	void buildCharIndex(const wstring& content) { // This version buildCharIndex() Compatiable with python version char_rnn dictionary
-		int n = 1;
-		charIndices['\0'] = 0; // padding character
-		index2chars.push_back(0); // padding character index
-		for (auto c : content)
-			if (charIndices.find(c) == charIndices.end()) {
-				charIndices[c] = n++;
-				index2chars.push_back(c);
-			}
-	}
-//	void buildCharIndex(wstring& content) {
-//		for (auto c : content)
-//			charIndices[c]++; // char-frequency map; then char-index map
-//		vector<tuple<wchar_t, mx_float>> characters;
-//		for (auto& iter : charIndices)
-//			characters.push_back(make_tuple(iter.first, iter.second));
-//		sort(characters.begin(), characters.end(), [](const tuple<wchar_t, mx_float>& a, const tuple<wchar_t, mx_float>& b) { return get<1>(a) > get<1>(b); });
-//		mx_float index = 1; //0 is left for zero-padding
-//		index2chars.clear();
-//		index2chars.push_back(0); //zero-padding
-//		for (auto& t : characters) {
-//			charIndices[get<0>(t)] = index++;
-//			index2chars.push_back(get<0>(t));
-//		}
-//	}
+  void buildCharIndex(const wstring& content) {
+  // This version buildCharIndex() Compatiable with python version char_rnn dictionary
+    int n = 1;
+    charIndices['\0'] = 0;  // padding character
+    index2chars.push_back(0);  // padding character index
+    for (auto c : content)
+      if (charIndices.find(c) == charIndices.end()) {
+        charIndices[c] = n++;
+        index2chars.push_back(c);
+      }
+  }
+//  void buildCharIndex(wstring& content) {
+//    for (auto c : content)
+//      charIndices[c]++; // char-frequency map; then char-index map
+//    vector<tuple<wchar_t, mx_float>> characters;
+//    for (auto& iter : charIndices)
+//      characters.push_back(make_tuple(iter.first, iter.second));
+//    sort(characters.begin(), characters.end(), [](const tuple<wchar_t, mx_float>& a,
+//      const tuple<wchar_t, mx_float>& b) { return get<1>(a) > get<1>(b); });
+//    mx_float index = 1; //0 is left for zero-padding
+//    index2chars.clear();
+//    index2chars.push_back(0); //zero-padding
+//    for (auto& t : characters) {
+//      charIndices[get<0>(t)] = index++;
+//      index2chars.push_back(get<0>(t));
+//    }
+//  }
 
-	inline wchar_t character(int i) {
-		return index2chars[i];
-	}
+  inline wchar_t character(int i) {
+    return index2chars[i];
+  }
 
-	inline mx_float index(wchar_t c) {
-		return charIndices[c];
-	}
+  inline mx_float index(wchar_t c) {
+    return charIndices[c];
+  }
 
-	void saveCharIndices(const string file) {
-		wofstream ofs(file, ios::binary);
-		if (ofs) {
-			ofs.write(index2chars.data() + 1, index2chars.size() - 1);
-			ofs.close();
-		}
-	}
+  void saveCharIndices(const string file) {
+    wofstream ofs(file, ios::binary);
+    if (ofs) {
+      ofs.write(index2chars.data() + 1, index2chars.size() - 1);
+      ofs.close();
+    }
+  }
 
-	static tuple<unordered_map<wchar_t, mx_float>, vector<wchar_t>> loadCharIndices(const string file) {
-		wifstream ifs(file, ios::binary);
-		unordered_map<wchar_t, mx_float> map;
-		vector<wchar_t> chars;
-		if (ifs) {
-			wostringstream os;
-			os << ifs.rdbuf();
-			int n = 1;
-			map[L'\0'] = 0;
-			chars.push_back(L'\0');
-			for (auto c : os.str()) {
-				map[c] = (mx_float) n++;
-				chars.push_back(c);
-			}
-		}
-		return {map, chars};
-	}
+  static tuple<unordered_map<wchar_t, mx_float>, vector<wchar_t>> loadCharIndices(
+      const string file) {
+    wifstream ifs(file, ios::binary);
+    unordered_map<wchar_t, mx_float> map;
+    vector<wchar_t> chars;
+    if (ifs) {
+      wostringstream os;
+      os << ifs.rdbuf();
+      int n = 1;
+      map[L'\0'] = 0;
+      chars.push_back(L'\0');
+      for (auto c : os.str()) {
+        map[c] = (mx_float) n++;
+        chars.push_back(c);
+      }
+    }
+    return {map, chars};
+  }
 
-	vector<vector<mx_float>> convertTextToSequences(const wstring& content, wchar_t spliter) {
-		vector<vector<mx_float>> sequences;
-		sequences.push_back(vector<mx_float>());
-		for (auto c : content)
-			if (c == spliter && !sequences.back().empty())
-				sequences.push_back(vector<mx_float>());
-			else
-				sequences.back().push_back(charIndices[c]);
-		return sequences;
-	}
+  vector<vector<mx_float>> convertTextToSequences(const wstring& content, wchar_t spliter) {
+    vector<vector<mx_float>> sequences;
+    sequences.push_back(vector<mx_float>());
+    for (auto c : content)
+      if (c == spliter && !sequences.back().empty())
+        sequences.push_back(vector<mx_float>());
+      else
+        sequences.back().push_back(charIndices[c]);
+    return sequences;
+  }
 };
 
-void OutputPerplexity(NDArray& labels, NDArray& output)
-{
-	vector<mx_float> charIndices, a;
-	labels.SyncCopyToCPU(&charIndices, 0L);
-	output.SyncCopyToCPU(&a, 0)/*4128*84*/;
-	mx_float loss = 0;
-	int batchSize = labels.GetShape()[0]/*32*/, sequenceLength = labels.GetShape()[1]/*129*/, nSamples = output.GetShape()[0]/*4128*/, vocabSize = output.GetShape()[1]/*84*/;
-	for (int n = 0; n < nSamples; n++) {
-		int row = n % batchSize, column = n / batchSize, labelOffset = column + row * sequenceLength; //Search based on column storage: labels.T
-		mx_float safe_value = max(1e-10f, a[vocabSize * n + int(charIndices[labelOffset])]);
-		loss += -log(safe_value); // Calculate negative log-likelihood
-	}
-	loss = exp(loss / nSamples);
-	cout << "Train-Perplexity=" << loss << endl;
+void OutputPerplexity(NDArray* labels, NDArray* output) {
+  vector<mx_float> charIndices, a;
+  labels->SyncCopyToCPU(&charIndices, 0L);
+  output->SyncCopyToCPU(&a, 0)/*4128*84*/;
+  mx_float loss = 0;
+  int batchSize = labels->GetShape()[0]/*32*/, sequenceLength = labels->GetShape()[1]/*129*/,
+      nSamples = output->GetShape()[0]/*4128*/, vocabSize = output->GetShape()[1]/*84*/;
+  for (int n = 0; n < nSamples; n++) {
+    int row = n % batchSize, column = n / batchSize, labelOffset = column +
+        row * sequenceLength;  // Search based on column storage: labels.T
+    mx_float safe_value = max(1e-10f, a[vocabSize * n +
+                                    static_cast<int>(charIndices[labelOffset])]);
+    loss += -log(safe_value);  // Calculate negative log-likelihood
+  }
+  loss = exp(loss / nSamples);
+  cout << "Train-Perplexity=" << loss << endl;
 }
 
-void SaveCheckpoint(const string filepath, Symbol net, Executor* exe)
-{
-	map<string, NDArray> params;
-	for (auto iter : exe->arg_dict())
-		if (iter.first.find("_init_") == string::npos && iter.first.rfind("data") != iter.first.length() - 4 && iter.first.rfind("label") != iter.first.length() - 5)
-			params.insert({"arg:" + iter.first, iter.second});
-	for (auto iter : exe->aux_dict())
-			params.insert({"aux:" + iter.first, iter.second});
-	NDArray::Save(filepath, params);
+void SaveCheckpoint(const string filepath, Symbol net, Executor* exe) {
+  map<string, NDArray> params;
+  for (auto iter : exe->arg_dict())
+    if (iter.first.find("_init_") == string::npos
+        && iter.first.rfind("data") != iter.first.length() - 4
+        && iter.first.rfind("label") != iter.first.length() - 5)
+      params.insert({"arg:" + iter.first, iter.second});
+  for (auto iter : exe->aux_dict())
+      params.insert({"aux:" + iter.first, iter.second});
+  NDArray::Save(filepath, params);
 }
 
-void LoadCheckpoint(const string filepath, Executor* exe)
-{
-	map<std::string, NDArray> params = NDArray::LoadToMap(filepath);
-	for (auto iter : params) {
-		string type = iter.first.substr(0, 4);
-		string name = iter.first.substr(4);
-		NDArray target;
-		if (type == "arg:")
-			target = exe->arg_dict()[name];
-		else if (type == "aux:")
-			target = exe->aux_dict()[name];
-		else
-			continue;
-		iter.second.CopyTo(&target);
-	}
+void LoadCheckpoint(const string filepath, Executor* exe) {
+  map<std::string, NDArray> params = NDArray::LoadToMap(filepath);
+  for (auto iter : params) {
+    string type = iter.first.substr(0, 4);
+    string name = iter.first.substr(4);
+    NDArray target;
+    if (type == "arg:")
+      target = exe->arg_dict()[name];
+    else if (type == "aux:")
+      target = exe->aux_dict()[name];
+    else
+      continue;
+    iter.second.CopyTo(&target);
+  }
 }
 
 int input_dim = 0;/*84*/
@@ -372,267 +388,275 @@ int num_embed = 256;
 int num_lstm_layer = 3;
 int num_hidden = 512;
 mx_float dropout = 0.2;
-void train(const string file, int batch_size, int max_epoch)
-{
-	Context device(DeviceType::kGPU, 0);
-	BucketSentenceIter dataIter(file, batch_size, device);
-	string prefix = file.substr(0, file.rfind("."));
-	dataIter.saveCharIndices(prefix + ".dictionary");
+void train(const string file, int batch_size, int max_epoch) {
+  Context device(DeviceType::kGPU, 0);
+  BucketSentenceIter dataIter(file, batch_size, device);
+  string prefix = file.substr(0, file.rfind("."));
+  dataIter.saveCharIndices(prefix + ".dictionary");
 
-	input_dim = (int) dataIter.characterSize();
-	sequence_length_max = dataIter.maxSequenceLength();
+  input_dim = static_cast<int>(dataIter.characterSize());
+  sequence_length_max = dataIter.maxSequenceLength();
 
-	auto RNN = LSTMUnroll(num_lstm_layer, sequence_length_max, input_dim, num_hidden, num_embed, dropout);
-	map<string, NDArray> args_map;
-	args_map["data"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
-	args_map["softmax_label"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
-	for (int i = 0; i < num_lstm_layer; i++) {
-		string key = "l" + to_string(i) + "_init_";
-		args_map[key + "c"] = NDArray(Shape(batch_size, num_hidden), device, false);
-		args_map[key + "h"] = NDArray(Shape(batch_size, num_hidden), device, false);
-	}
-	vector<mx_float> zeros(batch_size * num_hidden, 0);
-	Executor* exe = RNN.SimpleBind(device, args_map); // RNN.SimpleBind(device, args_map, {}, {{"data", kNullOp}});
+  auto RNN = LSTMUnroll(num_lstm_layer, sequence_length_max, input_dim, num_hidden,
+      num_embed, batch_size, dropout);
+  map<string, NDArray> args_map;
+  args_map["data"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
+  args_map["softmax_label"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
+  for (int i = 0; i < num_lstm_layer; i++) {
+    string key = "l" + to_string(i) + "_init_";
+    args_map[key + "c"] = NDArray(Shape(batch_size, num_hidden), device, false);
+    args_map[key + "h"] = NDArray(Shape(batch_size, num_hidden), device, false);
+  }
+  vector<mx_float> zeros(batch_size * num_hidden, 0);
+  // RNN.SimpleBind(device, args_map, {}, {{"data", kNullOp}});
+  Executor* exe = RNN.SimpleBind(device, args_map);
 
-	Xavier xavier = Xavier(Xavier::gaussian, Xavier::in, 2.34);
-	for (auto &arg : exe->arg_dict())
-		xavier(arg.first, &arg.second);
+  Xavier xavier = Xavier(Xavier::gaussian, Xavier::in, 2.34);
+  for (auto &arg : exe->arg_dict())
+    xavier(arg.first, &arg.second);
 
-	mx_float learning_rate = 0.0002;
-	mx_float weight_decay = 0.000002;
-	Optimizer* opt = OptimizerRegistry::Find("ccsgd");
-//	opt->SetParam("momentum", 0.9)->SetParam("rescale_grad", 1.0 / batch_size)->SetParam("clip_gradient", 10);
+  mx_float learning_rate = 0.0002;
+  mx_float weight_decay = 0.000002;
+  Optimizer* opt = OptimizerRegistry::Find("ccsgd");
+//  opt->SetParam("momentum", 0.9)->SetParam("rescale_grad", 1.0 / batch_size)
+//  ->SetParam("clip_gradient", 10);
 
-	for (int epoch = 0; epoch < max_epoch; ++epoch) {
-		dataIter.Reset();
-		auto tic = chrono::system_clock::now();
-		while (dataIter.Next()) {
-			auto data_batch = dataIter.GetDataBatch();
-			data_batch.data.CopyTo(&exe->arg_dict()["data"]);
-			data_batch.label.CopyTo(&exe->arg_dict()["softmax_label"]);
-			for (int l = 0; l < num_lstm_layer; l++) {
-				string key = "l" + to_string(l) + "_init_";
-				exe->arg_dict()[key + "c"].SyncCopyFromCPU(zeros);
-				exe->arg_dict()[key + "h"].SyncCopyFromCPU(zeros);
-			}
-			NDArray::WaitAll();
+  for (int epoch = 0; epoch < max_epoch; ++epoch) {
+    dataIter.Reset();
+    auto tic = chrono::system_clock::now();
+    while (dataIter.Next()) {
+      auto data_batch = dataIter.GetDataBatch();
+      data_batch.data.CopyTo(&exe->arg_dict()["data"]);
+      data_batch.label.CopyTo(&exe->arg_dict()["softmax_label"]);
+      for (int l = 0; l < num_lstm_layer; l++) {
+        string key = "l" + to_string(l) + "_init_";
+        exe->arg_dict()[key + "c"].SyncCopyFromCPU(zeros);
+        exe->arg_dict()[key + "h"].SyncCopyFromCPU(zeros);
+      }
+      NDArray::WaitAll();
 
-			exe->Forward(true);
-			exe->Backward();
-			exe->UpdateAll(opt, learning_rate, weight_decay);
-			NDArray::WaitAll();
-		}
-		auto toc = chrono::system_clock::now();
-		cout << "Epoch[" << epoch << "] Time Cost:" << chrono::duration_cast<chrono::seconds>(toc - tic).count() << " seconds ";
-		OutputPerplexity(exe->arg_dict()["softmax_label"], exe->outputs[0]);
-		string filepath = prefix + "-" + to_string(epoch + 1) + ".params";
-		SaveCheckpoint(filepath, RNN, exe);
-	}
+      exe->Forward(true);
+      exe->Backward();
+      exe->UpdateAll(opt, learning_rate, weight_decay);
+      NDArray::WaitAll();
+    }
+    auto toc = chrono::system_clock::now();
+    cout << "Epoch[" << epoch << "] Time Cost:" <<
+        chrono::duration_cast<chrono::seconds>(toc - tic).count() << " seconds ";
+    OutputPerplexity(&exe->arg_dict()["softmax_label"], &exe->outputs[0]);
+    string filepath = prefix + "-" + to_string(epoch + 1) + ".params";
+    SaveCheckpoint(filepath, RNN, exe);
+  }
 }
 
 void trainWithBuiltInRNNOp(const string file, int batch_size, int max_epoch)
 {
-	Context device(DeviceType::kGPU, 0);
-	BucketSentenceIter dataIter(file, batch_size, device);
-	string prefix = file.substr(0, file.rfind("."));
-	dataIter.saveCharIndices(prefix + ".dictionary");
+  Context device(DeviceType::kGPU, 0);
+  BucketSentenceIter dataIter(file, batch_size, device);
+  string prefix = file.substr(0, file.rfind("."));
+  dataIter.saveCharIndices(prefix + ".dictionary");
 
-	input_dim = (int) dataIter.characterSize();
-	sequence_length_max = dataIter.maxSequenceLength();
+  input_dim = (int) dataIter.characterSize();
+  sequence_length_max = dataIter.maxSequenceLength();
 
-	auto RNN = LSTMWithBuiltInRNNOp(num_lstm_layer, sequence_length_max, input_dim, num_hidden, num_embed, dropout);
-	map<string, NDArray> args_map;
-	args_map["data"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
-	args_map["LSTM_init_c"] = NDArray(Shape(batch_size, num_lstm_layer, num_hidden), device, false);
-	args_map["LSTM_init_h"] = NDArray(Shape(batch_size, num_lstm_layer, num_hidden), device, false);
-	args_map["softmax_label"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
-	vector<mx_float> zeros(batch_size * num_lstm_layer * num_hidden, 0);
-	Executor* exe = RNN.SimpleBind(device, args_map); // RNN.SimpleBind(device, args_map, {}, {{"data", kNullOp}});
+  auto RNN = LSTMWithBuiltInRNNOp(num_lstm_layer, sequence_length_max, input_dim, num_hidden,
+   num_embed, dropout);
+  map<string, NDArray> args_map;
+  args_map["data"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
+  args_map["LSTM_init_c"] = NDArray(Shape(batch_size, num_lstm_layer, num_hidden), device, false);
+  args_map["LSTM_init_h"] = NDArray(Shape(batch_size, num_lstm_layer, num_hidden), device, false);
+  args_map["softmax_label"] = NDArray(Shape(batch_size, sequence_length_max), device, false);
+  vector<mx_float> zeros(batch_size * num_lstm_layer * num_hidden, 0);
+  Executor* exe = RNN.SimpleBind(device, args_map);
 
-	Xavier xavier = Xavier(Xavier::gaussian, Xavier::in, 2.34);
-	for (auto &arg : exe->arg_dict())
-		xavier(arg.first, &arg.second);
+  Xavier xavier = Xavier(Xavier::gaussian, Xavier::in, 2.34);
+  for (auto &arg : exe->arg_dict())
+    xavier(arg.first, &arg.second);
 
-	mx_float learning_rate = 0.0002;
-	mx_float weight_decay = 0.000002;
-	Optimizer* opt = OptimizerRegistry::Find("ccsgd");
-//	opt->SetParam("momentum", 0.9)->SetParam("rescale_grad", 1.0 / batch_size)->SetParam("clip_gradient", 10);
+  mx_float learning_rate = 0.0002;
+  mx_float weight_decay = 0.000002;
+  Optimizer* opt = OptimizerRegistry::Find("ccsgd");
+//  opt->SetParam("momentum", 0.9)->SetParam("rescale_grad", 1.0 / batch_size)
+//  ->SetParam("clip_gradient", 10);
 
-	for (int epoch = 0; epoch < max_epoch; ++epoch) {
-		dataIter.Reset();
-		auto tic = chrono::system_clock::now();
-		while (dataIter.Next()) {
-			auto data_batch = dataIter.GetDataBatch();
-			data_batch.data.CopyTo(&exe->arg_dict()["data"]);
-			data_batch.label.CopyTo(&exe->arg_dict()["softmax_label"]);
-			exe->arg_dict()["LSTM_init_c"].SyncCopyFromCPU(zeros);
-			exe->arg_dict()["LSTM_init_h"].SyncCopyFromCPU(zeros);
-			NDArray::WaitAll();
+  for (int epoch = 0; epoch < max_epoch; ++epoch) {
+    dataIter.Reset();
+    auto tic = chrono::system_clock::now();
+    while (dataIter.Next()) {
+      auto data_batch = dataIter.GetDataBatch();
+      data_batch.data.CopyTo(&exe->arg_dict()["data"]);
+      data_batch.label.CopyTo(&exe->arg_dict()["softmax_label"]);
+      exe->arg_dict()["LSTM_init_c"].SyncCopyFromCPU(zeros);
+      exe->arg_dict()["LSTM_init_h"].SyncCopyFromCPU(zeros);
+      NDArray::WaitAll();
 
-			exe->Forward(true);
-			exe->Backward();
-			exe->UpdateAll(opt, learning_rate, weight_decay);
-			NDArray::WaitAll();
-		}
-		auto toc = chrono::system_clock::now();
-		cout << "Epoch[" << epoch << "] Time Cost:" << chrono::duration_cast<chrono::seconds>(toc - tic).count() << " seconds ";
-		OutputPerplexity(exe->arg_dict()["softmax_label"], exe->outputs[0]);
-		string filepath = prefix + "-" + to_string(epoch + 1) + ".params";
-		SaveCheckpoint(filepath, RNN, exe);
-	}
+      exe->Forward(true);
+      exe->Backward();
+      exe->UpdateAll(opt, learning_rate, weight_decay);
+      NDArray::WaitAll();
+    }
+    auto toc = chrono::system_clock::now();
+    cout << "Epoch[" << epoch << "] Time Cost:" <<
+        chrono::duration_cast<chrono::seconds>(toc - tic).count() << " seconds ";
+    OutputPerplexity(exe->arg_dict()["softmax_label"], exe->outputs[0]);
+    string filepath = prefix + "-" + to_string(epoch + 1) + ".params";
+    SaveCheckpoint(filepath, RNN, exe);
+  }
 }
 
-void predict(wstring& text, int sequence_length, const string param_file, const string dictionary_file)
-{
-	Context device(DeviceType::kGPU, 0);
-	auto results = BucketSentenceIter::loadCharIndices(dictionary_file);
-	auto dictionary = get<0>(results);
-	auto charIndices = get<1>(results);
-	input_dim = (int) charIndices.size();
-	auto RNN = LSTMUnroll(num_lstm_layer, 1, input_dim, num_hidden, num_embed, 0);
+void predict(wstring* text, int sequence_length, const string param_file,
+    const string dictionary_file) {
+  Context device(DeviceType::kGPU, 0);
+  auto results = BucketSentenceIter::loadCharIndices(dictionary_file);
+  auto dictionary = get<0>(results);
+  auto charIndices = get<1>(results);
+  input_dim = static_cast<int>(charIndices.size());
+  auto RNN = LSTMUnroll(num_lstm_layer, 1, input_dim, num_hidden, num_embed, 1, 0);
 
-	map<string, NDArray> args_map;
-	args_map["data"] = NDArray(Shape(1, 1), device, false);
-	args_map["softmax_label"] = NDArray(Shape(1, 1), device, false);
-	vector<mx_float> zeros(1 * num_hidden, 0);
-	for (int l = 0; l < num_lstm_layer; l++) {
-		string key = "l" + to_string(l) + "_init_";
-		args_map[key + "c"] = NDArray(Shape(1, num_hidden), device, false);
-		args_map[key + "h"] = NDArray(Shape(1, num_hidden), device, false);
-		args_map[key + "c"].SyncCopyFromCPU(zeros);
-		args_map[key + "h"].SyncCopyFromCPU(zeros);
-	}
-	Executor* exe = RNN.SimpleBind(device, args_map);
-	LoadCheckpoint(param_file, exe);
+  map<string, NDArray> args_map;
+  args_map["data"] = NDArray(Shape(1, 1), device, false);
+  args_map["softmax_label"] = NDArray(Shape(1, 1), device, false);
+  vector<mx_float> zeros(1 * num_hidden, 0);
+  for (int l = 0; l < num_lstm_layer; l++) {
+    string key = "l" + to_string(l) + "_init_";
+    args_map[key + "c"] = NDArray(Shape(1, num_hidden), device, false);
+    args_map[key + "h"] = NDArray(Shape(1, num_hidden), device, false);
+    args_map[key + "c"].SyncCopyFromCPU(zeros);
+    args_map[key + "h"].SyncCopyFromCPU(zeros);
+  }
+  Executor* exe = RNN.SimpleBind(device, args_map);
+  LoadCheckpoint(param_file, exe);
 
-	mx_float index;
-	wchar_t next;
-	vector<mx_float> softmax;
-	softmax.resize(input_dim);
-	for (auto c : text) {
-		exe->arg_dict()["data"].SyncCopyFromCPU(&dictionary[c], 1);
-		exe->Forward(false);
+  mx_float index;
+  wchar_t next;
+  vector<mx_float> softmax;
+  softmax.resize(input_dim);
+  for (auto c : *text) {
+    exe->arg_dict()["data"].SyncCopyFromCPU(&dictionary[c], 1);
+    exe->Forward(false);
 
-		exe->outputs[0].SyncCopyToCPU(softmax.data(), input_dim);
-		for (int l = 0; l < num_lstm_layer; l++) {
-			string key = "l" + to_string(l) + "_init_";
-			exe->outputs[l * 2 + 1].CopyTo(&args_map[key + "c"]);
-			exe->outputs[l * 2 + 2].CopyTo(&args_map[key + "h"]);
-		}
+    exe->outputs[0].SyncCopyToCPU(softmax.data(), input_dim);
+    for (int l = 0; l < num_lstm_layer; l++) {
+      string key = "l" + to_string(l) + "_init_";
+      exe->outputs[l * 2 + 1].CopyTo(&args_map[key + "c"]);
+      exe->outputs[l * 2 + 2].CopyTo(&args_map[key + "h"]);
+    }
 
-		size_t n = max_element(softmax.begin(), softmax.end()) - softmax.begin();
-		index = (mx_float) n;
-		next = charIndices[n];
-	}
-	text.push_back(next);
+    size_t n = max_element(softmax.begin(), softmax.end()) - softmax.begin();
+    index = (mx_float) n;
+    next = charIndices[n];
+  }
+  text.push_back(next);
 
-	for (int i = 0; i < sequence_length; i++) {
-		exe->arg_dict()["data"].SyncCopyFromCPU(&index, 1);
-		exe->Forward(false);
+  for (int i = 0; i < sequence_length; i++) {
+    exe->arg_dict()["data"].SyncCopyFromCPU(&index, 1);
+    exe->Forward(false);
 
-		exe->outputs[0].SyncCopyToCPU(softmax.data(), input_dim);
-		for (int l = 0; l < num_lstm_layer; l++) {
-			string key = "l" + to_string(l) + "_init_";
-			exe->outputs[l * 2 + 1].CopyTo(&args_map[key + "c"]);
-			exe->outputs[l * 2 + 2].CopyTo(&args_map[key + "h"]);
-		}
+    exe->outputs[0].SyncCopyToCPU(softmax.data(), input_dim);
+    for (int l = 0; l < num_lstm_layer; l++) {
+      string key = "l" + to_string(l) + "_init_";
+      exe->outputs[l * 2 + 1].CopyTo(&args_map[key + "c"]);
+      exe->outputs[l * 2 + 2].CopyTo(&args_map[key + "h"]);
+    }
 
-		size_t n = max_element(softmax.begin(), softmax.end()) - softmax.begin();
-		index = (mx_float) n;
-		next = charIndices[n];
-		text.push_back(next);
-	}
+    size_t n = max_element(softmax.begin(), softmax.end()) - softmax.begin();
+    index = (mx_float) n;
+    next = charIndices[n];
+    text.push_back(next);
+  }
 }
 
 void predictWithBuiltInRNNOp(wstring& text, int sequence_length, const string param_file, const string dictionary_file)
 {
-	Context device(DeviceType::kGPU, 0);
-	auto results = BucketSentenceIter::loadCharIndices(dictionary_file);
-	auto dictionary = get<0>(results);
-	auto charIndices = get<1>(results);
-	input_dim = (int) charIndices.size();
-	auto RNN = LSTMWithBuiltInRNNOp(num_lstm_layer, 1, input_dim, num_hidden, num_embed, 0);
+  Context device(DeviceType::kGPU, 0);
+  auto results = BucketSentenceIter::loadCharIndices(dictionary_file);
+  auto dictionary = get<0>(results);
+  auto charIndices = get<1>(results);
+  input_dim = (int) charIndices.size();
+  auto RNN = LSTMWithBuiltInRNNOp(num_lstm_layer, 1, input_dim, num_hidden, num_embed, 0);
 
-	map<string, NDArray> args_map;
-	args_map["data"] = NDArray(Shape(1), device, false);
-	args_map["softmax_label"] = NDArray(Shape(1), device, false);
-	vector<mx_float> zeros(1 * num_lstm_layer * num_hidden, 0);
-	args_map["LSTM_init_c"] = NDArray(Shape(1, num_lstm_layer, num_hidden), device, false);
-	args_map["LSTM_init_h"] = NDArray(Shape(1, num_lstm_layer, num_hidden), device, false);
-	args_map["LSTM_init_c"].SyncCopyFromCPU(zeros);
-	args_map["LSTM_init_h"].SyncCopyFromCPU(zeros);
-	Executor* exe = RNN.SimpleBind(device, args_map);
-	LoadCheckpoint(param_file, exe);
+  map<string, NDArray> args_map;
+  args_map["data"] = NDArray(Shape(1), device, false);
+  args_map["softmax_label"] = NDArray(Shape(1), device, false);
+  vector<mx_float> zeros(1 * num_lstm_layer * num_hidden, 0);
+  args_map["LSTM_init_c"] = NDArray(Shape(1, num_lstm_layer, num_hidden), device, false);
+  args_map["LSTM_init_h"] = NDArray(Shape(1, num_lstm_layer, num_hidden), device, false);
+  args_map["LSTM_init_c"].SyncCopyFromCPU(zeros);
+  args_map["LSTM_init_h"].SyncCopyFromCPU(zeros);
+  Executor* exe = RNN.SimpleBind(device, args_map);
+  LoadCheckpoint(param_file, exe);
 
-	mx_float index;
-	wchar_t next;
-	vector<mx_float> softmax;
-	softmax.resize(input_dim);
-	for (auto c : text) {
-		exe->arg_dict()["data"].SyncCopyFromCPU(&dictionary[c], 1);
-		exe->Forward(false);
+  mx_float index;
+  wchar_t next;
+  vector<mx_float> softmax;
+  softmax.resize(input_dim);
+  for (auto c : text) {
+    exe->arg_dict()["data"].SyncCopyFromCPU(&dictionary[c], 1);
+    exe->Forward(false);
 
-//		exe->arg_dict()["LSTM_init_c"].SyncCopyFromCPU(zeros);
-//		exe->arg_dict()["LSTM_init_h"].SyncCopyFromCPU(zeros);
-//		exe->outputs[l * 2 + 1].CopyTo(&args_map[key + "c"]);
-//		exe->outputs[l * 2 + 2].CopyTo(&args_map[key + "h"]);
+//    exe->arg_dict()["LSTM_init_c"].SyncCopyFromCPU(zeros);
+//    exe->arg_dict()["LSTM_init_h"].SyncCopyFromCPU(zeros);
+//    exe->outputs[l * 2 + 1].CopyTo(&args_map[key + "c"]);
+//    exe->outputs[l * 2 + 2].CopyTo(&args_map[key + "h"]);
 //
-//		for (int l = 0; l < num_lstm_layer; l++) {
-//			string key = "l" + to_string(l) + "_init_";
-//			exe->outputs[l * 2 + 1].CopyTo(&args_map[key + "c"]);
-//			exe->outputs[l * 2 + 2].CopyTo(&args_map[key + "h"]);
-//		}
+//    for (int l = 0; l < num_lstm_layer; l++) {
+//      string key = "l" + to_string(l) + "_init_";
+//      exe->outputs[l * 2 + 1].CopyTo(&args_map[key + "c"]);
+//      exe->outputs[l * 2 + 2].CopyTo(&args_map[key + "h"]);
+//    }
 
-		exe->outputs[0].SyncCopyToCPU(softmax.data(), input_dim);
-		size_t n = max_element(softmax.begin(), softmax.end()) - softmax.begin();
-		index = (mx_float) n;
-		next = charIndices[n];
-	}
-	text.push_back(next);
+    exe->outputs[0].SyncCopyToCPU(softmax.data(), input_dim);
+    size_t n = max_element(softmax.begin(), softmax.end()) - softmax.begin();
+    index = (mx_float) n;
+    next = charIndices[n];
+  }
+  text->push_back(next);
 
-	for (int i = 0; i < sequence_length; i++) {
-		exe->arg_dict()["data"].SyncCopyFromCPU(&index, 1);
-		exe->Forward(false);
+  for (int i = 0; i < sequence_length; i++) {
+    exe->arg_dict()["data"].SyncCopyFromCPU(&index, 1);
+    exe->Forward(false);
 
-		exe->outputs[0].SyncCopyToCPU(softmax.data(), input_dim);
-		for (int l = 0; l < num_lstm_layer; l++) {
-			string key = "l" + to_string(l) + "_init_";
-			exe->outputs[l * 2 + 1].CopyTo(&args_map[key + "c"]);
-			exe->outputs[l * 2 + 2].CopyTo(&args_map[key + "h"]);
-		}
+    exe->outputs[0].SyncCopyToCPU(softmax.data(), input_dim);
+    for (int l = 0; l < num_lstm_layer; l++) {
+      string key = "l" + to_string(l) + "_init_";
+      exe->outputs[l * 2 + 1].CopyTo(&args_map[key + "c"]);
+      exe->outputs[l * 2 + 2].CopyTo(&args_map[key + "h"]);
+    }
 
-		size_t n = max_element(softmax.begin(), softmax.end()) - softmax.begin();
-		index = (mx_float) n;
-		next = charIndices[n];
-		text.push_back(next);
-	}
+    size_t n = max_element(softmax.begin(), softmax.end()) - softmax.begin();
+    index = (mx_float) n;
+    next = charIndices[n];
+    text->push_back(next);
+  }
 }
 
-int main(int argc, char** argv)
-{
-	if (argc < 5) {
-		cout << "Usage for training: charRNN train[BuiltIn] {corpus file} {batch size} {max epoch}" << endl;
-		cout << "Usage for prediction: charRNN predict[BuiltIn] {params file} {dictionary file} {beginning of text}" << endl;
-		cout << "Note: The {params file} of train and trainBuiltIn are not compatible with each other." << endl;
-		return 0;
-	}
+int main(int argc, char** argv) {
+  if (argc < 5) {
+    cout << "Usage for training: charRNN train[BuiltIn] {corpus file} {batch size} {max epoch}" << endl;
+    cout << "Usage for prediction: charRNN predict[BuiltIn] {params file} {dictionary file} {beginning of text}" << endl;
+    cout << "Note: The {params file} of train and trainBuiltIn are not compatible with each other." << endl;
+    return 0;
+  }
 
-	string task = argv[1];
-	if (task == "train")
-		train(argv[2], atoi(argv[3]), atoi(argv[4])); // this function will generate dictionary file and params file.
-	else if (task == "trainBuiltIn")
-		trainWithBuiltInRNNOp(argv[2], atoi(argv[3]), atoi(argv[4])); // ditto
-	else if (task.find("predict") == 0) {
-		wstring text;// = L"If there is anyone out there who still doubts ";
-		for (char c : string(argv[4])) // Considering of extending to Chinese samples in future, use wchar_t instead of char
-			text.push_back((wchar_t) c);
-		if (task == "predict")
-			predict(text, 600, argv[2], argv[3]); // Python version predicts text default to random selecltions. Here I didn't write the random code, always choose the 'best' character. So the text length reduced to 600. Longer size often leads to repeated sentances, since training sequence length is only 129 for obama corpus.
-		else
-			predictWithBuiltInRNNOp(text, 600, argv[2], argv[3]); // ditto
-		wcout << text << endl;
-	}
+  string task = argv[1];
+  if (task == "train")
+    train(argv[2], atoi(argv[3]), atoi(argv[4])); // this function will generate dictionary file and params file.
+  else if (task == "trainBuiltIn")
+    trainWithBuiltInRNNOp(argv[2], atoi(argv[3]), atoi(argv[4])); // ditto
+  else if (task.find("predict") == 0) {
+    wstring text;// = L"If there is anyone out there who still doubts ";
+    for (char c : string(argv[4])) // Considering of extending to Chinese samples in future, use wchar_t instead of char
+      text.push_back((wchar_t) c);
+    /*Python version predicts text default to random selecltions. Here I didn't write the random
+    code, always choose the 'best' character. So the text length reduced to 600. Longer size often
+  leads to repeated sentances, since training sequence length is only 129 for obama corpus.*/
+    if (task == "predict")
+      predict(text, 600, argv[2], argv[3]);
+    else
+      predictWithBuiltInRNNOp(text, 600, argv[2], argv[3]); // ditto
+    wcout << text << endl;
+  }
 
-	MXNotifyShutdown();
-	return 0;
+  MXNotifyShutdown();
+  return 0;
 }

--- a/example/charRNN.cpp
+++ b/example/charRNN.cpp
@@ -456,7 +456,7 @@ class RNNXavier : public Xavier {
   }
  protected:
   virtual void InitDefault(NDArray* arr) {
-	  Xavier::InitWeight(arr);
+    Xavier::InitWeight(arr);
   }
 };
 

--- a/example/charRNN.cpp
+++ b/example/charRNN.cpp
@@ -689,11 +689,11 @@ int main(int argc, char** argv) {
   string task = argv[1];
   bool builtIn = task.find("BuiltIn") != string::npos;
   TIME_MAJOR = task.find("TimeMajor") != string::npos;
-  cout << "use BuiltIn cuDNN RNN:      " << builtIn << endl
-         << "use data as TimeMajor:       " << TIME_MAJOR << endl;
+  cout << "use BuiltIn cuDNN RNN: " << builtIn << endl
+         << "use data as TimeMajor: " << TIME_MAJOR << endl;
   if (task.find("train") == 0) {
-    cout << "train batch size: " << argv[3] << endl
-           << "train max epoch: " << argv[4] << endl;
+    cout << "train batch size:      " << argv[3] << endl
+           << "train max epoch:       " << argv[4] << endl;
     int start_epoch = argc > 5? atoi(argv[5]) : -1;
 	// this function will generate dictionary file and params file.
     if (builtIn)

--- a/example/googlenet.cpp
+++ b/example/googlenet.cpp
@@ -158,5 +158,6 @@ int main(int argc, char const *argv[]) {
     }
     LG << "Accuracy: " << acu.Get();
   }
+  MXNotifyShutdown();
   return 0;
 }

--- a/example/inception_bn.cpp
+++ b/example/inception_bn.cpp
@@ -183,5 +183,6 @@ int main(int argc, char const *argv[]) {
     LG << "Accuracy: " << acu.Get();
   }
   delete exec;
+  MXNotifyShutdown();
   return 0;
 }

--- a/example/lenet.cpp
+++ b/example/lenet.cpp
@@ -228,5 +228,6 @@ class Lenet {
 int main(int argc, char const *argv[]) {
   Lenet lenet;
   lenet.Run();
+  MXNotifyShutdown();
   return 0;
 }

--- a/example/lenet_with_mxdataiter.cpp
+++ b/example/lenet_with_mxdataiter.cpp
@@ -114,5 +114,6 @@ int main(int argc, char const *argv[]) {
     }
     LG << "Accuracy: " << acu.Get();
   }
+  MXNotifyShutdown();
   return 0;
 }

--- a/example/mlp.cpp
+++ b/example/mlp.cpp
@@ -156,6 +156,7 @@ void MLP() {
 
 int main(int argc, char** argv) {
   MLP();
+  MXNotifyShutdown();
   return 0;
 }
 

--- a/example/resnet.cpp
+++ b/example/resnet.cpp
@@ -186,5 +186,6 @@ int main(int argc, char const *argv[]) {
     LG << "Accuracy: " << acu.Get();
   }
   delete exec;
+  MXNotifyShutdown();
   return 0;
 }

--- a/include/mxnet-cpp/shape.h
+++ b/include/mxnet-cpp/shape.h
@@ -328,7 +328,7 @@ inline std::ostream &operator<<(std::ostream &os, const Shape &shape) {
   os << '(';
   for (index_t i = 0; i < shape.ndim(); ++i) {
     if (i != 0) os << ',';
-    os << shape[i];
+    os << static_cast<int>(shape[i]);  // Supports negative Shape 'special codes' for inferring
   }
   // python style tuple
   if (shape.ndim() == 1) os << ',';


### PR DESCRIPTION
 * Add faster version charRNN based on built-in cuDNN RNN operator, 10 times faster.
 * Add time major computation graph, although no substantial performance difference.
 * Support continuing training from last params file.
 * Rename params file epoch number starts from zero.

Bug fix: https://github.com/dmlc/MXNet.cpp/issues/64 crashing when program exits.
Bug fix: support Reshape negative special code for inferring, such as Reshape(label, Shape(), false, Shape(-1)), like python version does.