### PR TITLE
Output more informative error messsages.

### DIFF
--- a/include/mxnet-cpp/executor.hpp
+++ b/include/mxnet-cpp/executor.hpp
@@ -63,7 +63,7 @@ Executor::Executor(const Symbol &symbol, Context context,
                             grad_handles.data(), grad_reqs_uint.data(),
                             aux_handles.size(), aux_handles.data(),
                             shared_exec_handle, &handle_),
-           0);
+           0) << "\n " << MXGetLastError();
 
   mx_uint out_size;
   NDArrayHandle *out_array;

--- a/include/mxnet-cpp/symbol.hpp
+++ b/include/mxnet-cpp/symbol.hpp
@@ -181,7 +181,7 @@ void Symbol::InferShape(
                               &out_shape_size, &out_shape_ndim, &out_shape_data,
                               &aux_shape_size, &aux_shape_ndim, &aux_shape_data,
                               &complete),
-           0);
+           0) << "\n " << MXGetLastError();
 
   if (complete) {
     for (mx_uint i = 0; i < in_shape_size; ++i) {


### PR DESCRIPTION
Print out exception error messages to make it easier to find out why these calls failed.